### PR TITLE
Enable running long-term tests from pytest command line

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         flake8 --exclude=tests/* --ignore=E501
     - name: Test with pytest
       run: |
-        python -m pytest
+        python -m pytest -m "not xaod_runner"
     - name: Report coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       uses: codecov/codecov-action@v1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -100,6 +100,8 @@
     "python.dataScience.debugJustMyCode": false,
     "python.analysis.typeCheckingMode": "basic",
     "python.testing.pytestArgs": [
-        "--no-cov"
+        "--no-cov",
+        "-m",
+        " not xaod_runner"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -58,3 +58,21 @@ Template functions don't make sense yet in python.
 - Math functions are pulled from the C++ [`cmath` library](http://www.cplusplus.com/reference/cmath/): `sin`, `cos`, `tan`, `acos`, `asin`, `atan`, `atan2`, `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`, `exp`, `ldexp`, `log`, `ln`, `log10`, `exp2`, `expm1`, `ilogb`, `log1p`, `log2`, `scalbn`, `scalbln`, `pow`, `sqrt`, `cbrt`, `hypot`, `erf`, `erfc`, `tgamma`, `lgamma`, `ceil`, `floor`, `fmod`, `trunc`, `round`, `rint`, `nearbyint`, `remainder`, `remquo`, `copysign`, `nan`, `nextafter`, `nexttoward`, `fdim`, `fmax`, `fmin`, `fabs`, `abs`, `fma`.
 - Do not use `math.sin` in a call. However `sin` is just fine. If you do, you'll get an exception during resolution that it doesn't know how to translate `math`.
 - for things like `sum`, `min`, `max`, etc., use the `Sum`, `Min`, `Max` LINQ predicates.
+
+## Testing and Development
+
+Setting up the development environment:
+
+- After creating a virtual environment, do a setup-in-place: `pip install -e .[test]`
+
+To run tests:
+
+- `pytest -m "not xaod_runner"` will run the _fast_ tests.
+- `pytest -m "xaod_runner"` will run the slow tests that require docker installed on your command line. `docker` is involved via pythons `os.system` - so it needs to be available to the test runner.
+
+Contributing:
+
+- Develop in another repo or on a branch
+- Submit a PR against the `master` branch.
+
+In general, the `master` branch should pass all tests all the time. Releases are made by tagging on the master branch.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 addopts = --ignore=setup.py --cov=func_adl_xAOD --cov-report=term-missing --cov-config=.coveragerc --cov-report xml
 junit_family=legacy
+markers = 
+  xaod_runner: Run the C++ compile and backend tests

--- a/tests/xAODlib/control_tests.py
+++ b/tests/xAODlib/control_tests.py
@@ -4,8 +4,7 @@ from pathlib import Path
 import os
 
 # This mark should be turned off if we want to run long-running tests.
-run_long_running_tests = pytest.mark.skipif(True, reason='Long running tests, skipped except when run by hand')
-# run_long_running_tests = pytest.mark.skipif(False, reason="ok to run")
+run_long_running_tests = pytest.mark.xaod_runner
 
 # The file we can use in our test. It has only 10 events...
 local_path = 'tests/xAODlib/jets_10_events.root'


### PR DESCRIPTION
Running tests

- `pytest` will run *all* tests
- `pytest -m "not xaod_runner"` will run all tests but the slow ones
- `pytest -m xaod_runner` will run only the slow tests.
