### PR TITLE
Sequence of dictionaries can be converted to a ROOT file automatically 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 *.whl
+ANALYSIS.root

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ Template functions don't make sense yet in python.
 - Do not use `math.sin` in a call. However `sin` is just fine. If you do, you'll get an exception during resolution that it doesn't know how to translate `math`.
 - for things like `sum`, `min`, `max`, etc., use the `Sum`, `Min`, `Max` LINQ predicates.
 
+### Output Formats
+
+The `xAOD` code only renders the `func_adl` expression as a ROOT file. The ROOT file contains a simple `TTree` in its root directory.
+
+- If `AsROOTTTree` is the top level `func_adl` node, then the tree name and file name are taken from that expression. Only a sequence of python `tuples` or a single item can be understood by `AsROOTTTree`.
+- If a `Select` sequence of dictionary's is the last `func_adl` expression, then a file called `xaod_output.root` will be generated, and it will contain a `TTree` called `xaod_tree`, with column names taken from the dictionary keys.
+
+`ServiceX` (and the [`servicex` frontent package](https://pypi.org/project/servicex/)) can convert from ROOT to other formats like a `pandas.DataFrame` or an `awkward` array. This package contains a `LocalFile` object which can do something similar, but it is built only for testing.
+
 ## Testing and Development
 
 Setting up the development environment:

--- a/func_adl_xAOD/cpplib/cpp_representation.py
+++ b/func_adl_xAOD/cpplib/cpp_representation.py
@@ -215,6 +215,24 @@ class cpp_tuple(cpp_rep_base):
         return self._scope
 
 
+class cpp_dict(cpp_rep_base):
+    '''Represents a special kind of value = a dict, which is just a keyed container of other values.
+    This isn't a regular cpp_value in the sense it can't directly be put into C++ code. It must
+    be specially handled by the interpreter.
+    '''
+    def __init__(self, value: dict, scope: Union[gc_scope, gc_scope_top_level]):
+        super().__init__()
+        self._values = value
+        self._scope = scope
+
+    @property
+    def value_dict(self) -> dict:
+        return self._values
+
+    def scope(self) -> Union[gc_scope, gc_scope_top_level]:
+        return self._scope
+
+
 class cpp_sequence(cpp_rep_base):
     '''
     Represents a sequence of data. The `sequence_value` points to value of the item in the stream, and
@@ -230,7 +248,7 @@ class cpp_sequence(cpp_rep_base):
 
         sequence_value:         The value of the sequence - of the data items that are in sequence.
         iterator_value:         The iterator that is incremented to get the next value in the sequence. The
-                                iterator's scope is defined where it was created.
+                                iterators scope is defined where it was created.
         scope:                  The scope at which this sequence is declared. Note that this may be different
                                 from the of the interator if we are, for example, inside an if statement caused
                                 by a Where (or similar). If the `sequence_value` is an actual value, it will have

--- a/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
@@ -5,24 +5,25 @@ import ast
 import logging
 from typing import Any, Dict, List, Type, Union, cast
 
+import func_adl_xAOD.cpplib.cpp_ast as cpp_ast
+import func_adl_xAOD.cpplib.cpp_representation as crep
+import func_adl_xAOD.cpplib.cpp_types as ctyp
+import func_adl_xAOD.cpplib.math_utils  # (needed for math function injection)
+import func_adl_xAOD.xAODlib.EventCollections
+import func_adl_xAOD.xAODlib.Jets  # NOQA
+import func_adl_xAOD.xAODlib.result_handlers as rh
+import func_adl_xAOD.xAODlib.statement as statement
 from func_adl.ast.call_stack import argument_stack, stack_frame
 from func_adl.ast.func_adl_ast_utils import FuncADLNodeVisitor, function_call
 from func_adl.util_ast import lambda_unwrap
-from .utils import most_accurate_type
-
-import func_adl_xAOD.cpplib.cpp_ast as cpp_ast
 from func_adl_xAOD.cpplib.cpp_functions import FunctionAST
-import func_adl_xAOD.cpplib.cpp_representation as crep
-import func_adl_xAOD.cpplib.cpp_types as ctyp
 from func_adl_xAOD.cpplib.cpp_vars import unique_name
-import func_adl_xAOD.xAODlib.EventCollections
-import func_adl_xAOD.xAODlib.Jets  # NOQA
 from func_adl_xAOD.xAODlib.generated_code import generated_code
-import func_adl_xAOD.xAODlib.result_handlers as rh
-import func_adl_xAOD.xAODlib.statement as statement
-from func_adl_xAOD.xAODlib.util_scope import (
-    deepest_scope, gc_scope, gc_scope_top_level, top_level_scope)
+from func_adl_xAOD.xAODlib.util_scope import (deepest_scope, gc_scope,
+                                              gc_scope_top_level,
+                                              top_level_scope)
 
+from .utils import most_accurate_type
 
 # Convert between Python comparisons and C++.
 compare_operations = {

--- a/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
@@ -224,18 +224,21 @@ class query_ast_visitor(FuncADLNodeVisitor):
         # which we can feed to the root guy.
         values = r.sequence_value()
         if isinstance(values, crep.cpp_dict):
+            values = cast(crep.cpp_dict, values)
             col_values = values.value_dict.values()
             col_names = ast.List(elts=list(values.value_dict.keys()))
             s_tuple = crep.cpp_tuple(tuple(col_values), values.scope())
-            tuple_sequence = crep.cpp_sequence(s_tuple, r.iterator_value(), r.scope())
+            tuple_sequence = crep.cpp_sequence(s_tuple, r.iterator_value(), r.scope())  # type: ignore
             ast_dummy_source = ast.Constant(value=1)
-            ast_dummy_source.rep = tuple_sequence
+            ast_dummy_source.rep = tuple_sequence  # type: ignore
             ast_ttree = function_call('ResultTTree',
                                       [ast_dummy_source,
                                        col_names,
                                        ast.parse('"xaod_tree"').body[0].value,  # type: ignore
                                        ast.parse('"xaod_output"').body[0].value])  # type: ignore
-            return self.get_rep(ast_ttree)
+            result = self.get_rep(ast_ttree)
+            assert isinstance(result, rh.cpp_ttree_rep)
+            return result
         else:
             raise ValueError(f'Do not know how to convert a sequence of {r.sequence_value} into a ROOT file.')
 

--- a/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
@@ -201,17 +201,25 @@ class query_ast_visitor(FuncADLNodeVisitor):
     def get_as_ROOT(self, node: ast.AST) -> rh.cpp_ttree_rep:
         '''For a given node, return a root ttree rep.
 
-        This is used to make sure whatever the sequence is, that it returns a RootTTree.
+        This is used to make sure whatever the sequence is, that it returns a RootTTree. Use this
+        when the user may not have explicitly requested an output format. For example, if they end
+        with a tuple or a dict request, but not a AsAwkwardArray.
 
-        1. If the node already does that, it is returned.
-        1. If the node is a tuple, a ttree is made up
-        1. If the node is a dict, a ttree is made up.
+        1. If the top level ast node already requests an ROOTTTree, the representation is returned.
+        1. If the node is a sequence of dict's, a ttree is created that uses the dictionary
+           key's as column names.
+        1. Anything else causes an exception to be raised.
 
         Args:
-            node (ast.AST): node to convert to a tree
+            node (ast.AST): Top level `func_adl` expression that is to be renered as a ROOT file.
 
         Returns:
             rh.cpp_ttree_rep: The resulting node that will generate a root file.
+
+        Exceptions:
+            ValueError: If we end with something other than above, we raise `ValueError` to
+                        indicate that we can't figure out how to convert something into a ROOT
+                        file.
         '''
         r = self.get_rep(node)
         if isinstance(r, rh.cpp_ttree_rep):

--- a/func_adl_xAOD/xAODlib/result_handlers.py
+++ b/func_adl_xAOD/xAODlib/result_handlers.py
@@ -1,10 +1,10 @@
-# Code to work with the various types of data the executor is going to have to
-# return to the front end.
+import shutil
+from pathlib import Path
 
-from func_adl_xAOD.cpplib.cpp_representation import cpp_value
 import func_adl_xAOD.cpplib.cpp_types as ctyp
-from func_adl_xAOD.cpplib.cpp_vars import unique_name
 import uproot
+from func_adl_xAOD.cpplib.cpp_representation import cpp_value
+from func_adl_xAOD.cpplib.cpp_vars import unique_name
 
 
 ##################
@@ -17,30 +17,22 @@ class cpp_ttree_rep(cpp_value):
         self.treename = treename
 
 
-def extract_result_TTree(rep, run_dir):
+def extract_result_TTree(rep: cpp_ttree_rep, run_dir):
+    '''Copy the final file into a place that is "safe", and return that as a path.
+
+    The reason for this is that the temp directory we are using is about to be deleted!
+
+    Args:
+        rep (cpp_base_rep): The representation of the final result
+        run_dir ([type]): Directory where it ran
+
+    Raises:
+        Exception: [description]
     '''
-    Given the tree info, return the appropriate data to the client. In this case it is just
-    a full filename along with a tree name which the client can then use to open the tree.
-
-    rep: the cpp_tree_rep of the file that is going to come back.
-    run_dir: location where run wrote all the files
-
-    returns:
-    path_to_root_file: Full path to the file, copied into the local directory
-    tree_name: the name of the tree.
-    '''
-    raise Exception("extract_result_TTree is not yet implemented.")
-    # # This would be trivial other than the directory is about to be deleted. So in this case we are going to
-    # # need to copy the file over somewhere else!
-    # df_name = os.path.join(os.getcwd(), unique_name("datafile") + ".root")
-    # df_current = os.path.join(run_dir, 'data.root')
-
-    # if not os.path.exists(df_current):
-    #     raise Exception("Unable to find ROOT file '{0}' which contains the data we need!".format(df_current))
-
-    # shutil.copyfile(df_current, df_name)
-
-    # return ROOTTreeResult(True, [ROOTTreeFileInfo(df_name, rep.treename)])
+    current_path = run_dir / rep.filename
+    new_path = Path('.') / rep.filename
+    shutil.copy(current_path, new_path)
+    return new_path
 
 
 #############

--- a/tests/xAODlib/test_integrated_query.py
+++ b/tests/xAODlib/test_integrated_query.py
@@ -3,9 +3,11 @@ import asyncio
 from enum import auto
 import logging
 import os
+from pathlib import Path
 
 from func_adl import EventDataset
 import pytest
+import uproot
 
 from func_adl_xAOD.cpplib.math_utils import DeltaR
 from testfixtures import LogCapture
@@ -69,6 +71,24 @@ def test_flatten_array():
         .value()
     assert int(training_df.iloc[0]['JetPt']) == 257
     assert int(training_df.iloc[0]['JetPt']) != int(training_df.iloc[1]['JetPt'])
+
+def test_simple_dict_output():
+    # A very simple flattening of arrays
+    training_df = f_single \
+        .SelectMany(lambda e: e.Jets("AntiKt4EMTopoJets")) \
+        .Select(lambda j: {
+            'JetPt': j.pt()/1000.0
+            }) \
+        .value()
+    assert isinstance(training_df, Path)
+    assert training_df.exists()
+
+    with uproot.open(training_df) as input:
+        pd = input['xaod_tree'].pandas.df()  # type: ignore
+    print(pd)
+    assert int(pd.iloc[0]['JetPt']) == 257
+    assert int(pd.iloc[0]['JetPt']) != int(pd.iloc[1]['JetPt'])
+
 
 def test_First_two_outer_loops():
     # THis is a little tricky because the First there is actually running over one jet in the event. Further, the Where

--- a/tests/xAODlib/test_query_ast_visitor.py
+++ b/tests/xAODlib/test_query_ast_visitor.py
@@ -73,7 +73,7 @@ def test_as_root_rep_already_set():
     q = query_ast_visitor()
     node = ast.parse('1/1')
     v = rh.cpp_ttree_rep('junk', 'dude', gc_scope_top_level())
-    node.rep = v
+    node.rep = v  # type: ignore
 
     assert v is q.get_as_ROOT(node)
 
@@ -82,10 +82,10 @@ def test_as_root_as_dict():
     q = query_ast_visitor()
     node = ast.parse('1/1')
     dict_obj = crep.cpp_dict({ast.Constant(value='hi'): crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal(int))}, gc_scope_top_level())
-    sequence = crep.cpp_sequence(dict_obj,
+    sequence = crep.cpp_sequence(dict_obj,  # type: ignore
                                  crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal(int)),
                                  gc_scope_top_level())
-    node.rep = sequence
+    node.rep = sequence  # type: ignore
     as_root = q.get_as_ROOT(node)
 
     assert isinstance(as_root, rh.cpp_ttree_rep)

--- a/tests/xAODlib/test_query_ast_visitor.py
+++ b/tests/xAODlib/test_query_ast_visitor.py
@@ -1,8 +1,10 @@
 # Some very direct white box testing
 import ast
+from func_adl_xAOD.xAODlib.util_scope import gc_scope_top_level
 from func_adl_xAOD.xAODlib.ast_to_cpp_translator import query_ast_visitor
 import func_adl_xAOD.cpplib.cpp_representation as crep
 import func_adl_xAOD.cpplib.cpp_types as ctyp
+import func_adl_xAOD.xAODlib.result_handlers as rh
 
 
 def test_binary_plus_return_type_1():
@@ -65,3 +67,25 @@ def test_binary_divide_return_type_2():
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'
+
+
+def test_as_root_rep_already_set():
+    q = query_ast_visitor()
+    node = ast.parse('1/1')
+    v = rh.cpp_ttree_rep('junk', 'dude', gc_scope_top_level())
+    node.rep = v
+
+    assert v is q.get_as_ROOT(node)
+
+
+def test_as_root_as_dict():
+    q = query_ast_visitor()
+    node = ast.parse('1/1')
+    dict_obj = crep.cpp_dict({ast.Constant(value='hi'): crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal(int))}, gc_scope_top_level())
+    sequence = crep.cpp_sequence(dict_obj,
+                                 crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal(int)),
+                                 gc_scope_top_level())
+    node.rep = sequence
+    as_root = q.get_as_ROOT(node)
+
+    assert isinstance(as_root, rh.cpp_ttree_rep)

--- a/tests/xAODlib/test_xaod_executor.py
+++ b/tests/xAODlib/test_xaod_executor.py
@@ -21,6 +21,26 @@ def test_per_event_item():
     assert 1 == len(vs)
     assert "double" == str(vs[0].cpp_type())
 
+
+def test_dict_output():
+    r=dataset_for_testing() \
+        .Select(lambda e: e.EventInfo("EventInfo").runNumber()) \
+        .Select(lambda e: {'run_number': e}) \
+        .value()
+    vs = r.QueryVisitor._gc._class_vars
+    assert 1 == len(vs)
+    assert "double" == str(vs[0].cpp_type())
+
+
+def test_dict_output_fail_expansion():
+    my_old_dict = {1: 'hi'}
+    with pytest.raises(ValueError):
+        r=dataset_for_testing() \
+            .Select(lambda e: e.EventInfo("EventInfo").runNumber()) \
+            .Select(lambda e: {'run_number': e, **my_old_dict}) \
+            .value()
+
+
 def test_per_jet_item():
     # The following statement should be a straight sequence, not an array.
     r = dataset_for_testing() \

--- a/tests/xAODlib/test_xaod_executor.py
+++ b/tests/xAODlib/test_xaod_executor.py
@@ -23,7 +23,8 @@ def test_per_event_item():
 
 
 def test_dict_output():
-    r=dataset_for_testing() \
+    'This is integration testing - making sure the dict to root conversion works'
+    r=dataset_for_testing(root_result_only=True) \
         .Select(lambda e: e.EventInfo("EventInfo").runNumber()) \
         .Select(lambda e: {'run_number': e}) \
         .value()

--- a/tests/xAODlib/utils_for_testing.py
+++ b/tests/xAODlib/utils_for_testing.py
@@ -21,10 +21,13 @@ class dummy_executor:
         self.QueryVisitor = None
         self.ResultRep = None
 
-    def evaluate(self, a: ast.AST):
+    def evaluate(self, a: ast.AST, get_root: bool = False):
         rnr = atlas_xaod_executor()
         self.QueryVisitor = query_ast_visitor()
-        self.ResultRep = self.QueryVisitor.get_rep(rnr.apply_ast_transformations(a))
+        a_transformed = rnr.apply_ast_transformations(a)
+        self.ResultRep = \
+            self.QueryVisitor.get_as_ROOT(a_transformed) if get_root \
+            else self.QueryVisitor.get_rep(a_transformed)
         
 
     def get_result(self, q_visitor, result_rep):
@@ -35,9 +38,10 @@ class dummy_executor:
 
 
 class dataset_for_testing(EventDataset):
-    def __init__(self, qastle_roundtrip=False):
+    def __init__(self, qastle_roundtrip=False, root_result_only=False):
         EventDataset.__init__(self)
         self._q_roundtrip = qastle_roundtrip
+        self._force_root_result = root_result_only
 
     def __repr__(self) -> str:
         # When we need to move into a representation, use
@@ -63,7 +67,7 @@ class dataset_for_testing(EventDataset):
         # Use the dummy executor to process this, and return it.
         exe = dummy_executor()
         rnr = atlas_xaod_executor()
-        exe.evaluate(a)
+        exe.evaluate(a, self._force_root_result)
         return exe
 
 


### PR DESCRIPTION
This fixes #82

- If a top level function is a `Select` whose result is a dictionary, it can be rentered automatically as a ROOT file
- In this case, this removes the need for a `AsROOTTTree` function call.
- The dictionary keys are used as column names.
- Documentation and Tests were updated.
- Added a new method called `get_as_ROOT` to do this work. Integrated it into the xaod code.