### PR TITLE
Automatically Generate ROOT file from a single column

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ Template functions don't make sense yet in python.
 The `xAOD` code only renders the `func_adl` expression as a ROOT file. The ROOT file contains a simple `TTree` in its root directory.
 
 - If `AsROOTTTree` is the top level `func_adl` node, then the tree name and file name are taken from that expression. Only a sequence of python `tuples` or a single item can be understood by `AsROOTTTree`.
+- If a `Select` sequence of `int` or `double` is the last `func_adl` expression, then a file called `xaod_output.root` will be generated, and it will contain a `TTree` called `xaod_tree` with a single column, called `col1`.
+- If a `Select` sequence of a `tuple` is the last `func_adl` expression, then a file called `xaod_output.root` will be generated, and it will contain a `TTree` called `xaod_tree` with a columns named `col1`, `col2`, etc.
 - If a `Select` sequence of dictionary's is the last `func_adl` expression, then a file called `xaod_output.root` will be generated, and it will contain a `TTree` called `xaod_tree`, with column names taken from the dictionary keys.
 
-`ServiceX` (and the [`servicex` frontent package](https://pypi.org/project/servicex/)) can convert from ROOT to other formats like a `pandas.DataFrame` or an `awkward` array. This package contains a `LocalFile` object which can do something similar, but it is built only for testing.
+`ServiceX` (and the [`servicex` frontend package](https://pypi.org/project/servicex/)) can convert from ROOT to other formats like a `pandas.DataFrame` or an `awkward` array. This package contains a `LocalFile` object which can do something similar, but it is built only for testing.
 
 ## Testing and Development
 

--- a/func_adl_xAOD/cpplib/cpp_representation.py
+++ b/func_adl_xAOD/cpplib/cpp_representation.py
@@ -114,6 +114,9 @@ class cpp_value(cpp_rep_base):
         self._expression = cpp_expression
         self._cpp_type = cpp_type
 
+    def __str__(self) -> str:
+        return f'{str(self._cpp_type)} value (expression {self._expression})'
+
     def is_pointer(self):
         'Return true if this type is a pointer'
         if self._cpp_type is None:

--- a/func_adl_xAOD/cpplib/cpp_types.py
+++ b/func_adl_xAOD/cpplib/cpp_types.py
@@ -13,7 +13,7 @@ class terminal:
         self._is_pointer = is_pointer
 
     def __str__(self):
-        return self.type
+        return str(self.type)
 
     def is_pointer(self):
         return self._is_pointer

--- a/func_adl_xAOD/cpplib/cpp_types.py
+++ b/func_adl_xAOD/cpplib/cpp_types.py
@@ -3,11 +3,12 @@
 
 class terminal:
     'Represents something we cannot see inside, like float, or int, or bool'
-    def __init__(self, t, is_pointer=False):
-        '''
-        Initialize a terminal type
+    def __init__(self, t: str, is_pointer=False):
+        '''Create a terminal type - a type that we do not need to see inside
 
-        t:      The type as a string (valid in C++)
+        Args:
+            t (str): The name of the type (integer, double, xAOD::Jet, etc.)
+            is_pointer (bool, optional): True if this is a pointer. Defaults to False.
         '''
         self._type = t
         self._is_pointer = is_pointer
@@ -26,7 +27,7 @@ class terminal:
         elif self._type == "int":
             return "0"
         else:
-            raise Exception("Do not know a default value for the type '{0}'.".format(self._type))
+            raise Exception(f"Do not know a default value for the type '{self._type}'.")
 
     @property
     def type(self) -> str:

--- a/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
@@ -249,7 +249,7 @@ class query_ast_visitor(FuncADLNodeVisitor):
             assert isinstance(result, rh.cpp_ttree_rep)
             return result
         else:
-            raise ValueError(f'Do not know how to convert a sequence of {r.sequence_value} into a ROOT file.')
+            raise ValueError(f'Do not know how to convert a sequence of {r.sequence_value()} into a ROOT file.')
 
         raise NotImplementedError()
 

--- a/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
@@ -206,6 +206,7 @@ class query_ast_visitor(FuncADLNodeVisitor):
         with a tuple or a dict request, but not a AsAwkwardArray.
 
         1. If the top level ast node already requests an ROOTTTree, the representation is returned.
+        1. If the node is a sequence of `cpp_values`, then a single column tree is created.
         1. If the node is a sequence of dict's, a ttree is created that uses the dictionary
            key's as column names.
         1. Anything else causes an exception to be raised.
@@ -243,6 +244,15 @@ class query_ast_visitor(FuncADLNodeVisitor):
             ast_ttree = function_call('ResultTTree',
                                       [ast_dummy_source,
                                        col_names,
+                                       ast.parse('"xaod_tree"').body[0].value,  # type: ignore
+                                       ast.parse('"xaod_output"').body[0].value])  # type: ignore
+            result = self.get_rep(ast_ttree)
+            assert isinstance(result, rh.cpp_ttree_rep)
+            return result
+        elif isinstance(values, crep.cpp_value):
+            ast_ttree = function_call('ResultTTree',
+                                      [node,
+                                       ast.parse('"col1"').body[0].value,  # type: ignore
                                        ast.parse('"xaod_tree"').body[0].value,  # type: ignore
                                        ast.parse('"xaod_output"').body[0].value])  # type: ignore
             result = self.get_rep(ast_ttree)

--- a/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/xAODlib/ast_to_cpp_translator.py
@@ -249,6 +249,16 @@ class query_ast_visitor(FuncADLNodeVisitor):
             result = self.get_rep(ast_ttree)
             assert isinstance(result, rh.cpp_ttree_rep)
             return result
+        if isinstance(values, crep.cpp_tuple):
+            col_names = ast.List(elts=[ast.parse(f"'col{i}'").body[0].value for i, _ in enumerate(values.values())])
+            ast_ttree = function_call('ResultTTree',
+                                      [node,
+                                       col_names,
+                                       ast.parse('"xaod_tree"').body[0].value,  # type: ignore
+                                       ast.parse('"xaod_output"').body[0].value])  # type: ignore
+            result = self.get_rep(ast_ttree)
+            assert isinstance(result, rh.cpp_ttree_rep)
+            return result
         elif isinstance(values, crep.cpp_value):
             ast_ttree = function_call('ResultTTree',
                                       [node,

--- a/tests/xAODlib/test_integrated_query.py
+++ b/tests/xAODlib/test_integrated_query.py
@@ -90,6 +90,22 @@ def test_simple_dict_output():
     assert int(pd.iloc[0]['JetPt']) != int(pd.iloc[1]['JetPt'])
 
 
+def test_single_column_output():
+    # A very simple flattening of arrays
+    training_df = f_single \
+        .SelectMany(lambda e: e.Jets("AntiKt4EMTopoJets")) \
+        .Select(lambda j: j.pt()/1000.0) \
+        .value()
+    assert isinstance(training_df, Path)
+    assert training_df.exists()
+
+    with uproot.open(training_df) as input:
+        pd = input['xaod_tree'].pandas.df()  # type: ignore
+    print(pd)
+    assert int(pd.iloc[0]['col1']) == 257
+    assert int(pd.iloc[0]['col1']) != int(pd.iloc[1]['col1'])
+
+
 def test_First_two_outer_loops():
     # THis is a little tricky because the First there is actually running over one jet in the event. Further, the Where
     # on the number of tracks puts us another level down. So it is easy to produce code that compiles, but the First's if statement

--- a/tests/xAODlib/test_query_ast_visitor.py
+++ b/tests/xAODlib/test_query_ast_visitor.py
@@ -102,3 +102,17 @@ def test_as_root_as_single_column():
     as_root = q.get_as_ROOT(node)
 
     assert isinstance(as_root, rh.cpp_ttree_rep)
+
+
+def test_as_root_as_tuple():
+    q = query_ast_visitor()
+    node = ast.parse('1/1')
+    value_obj = crep.cpp_tuple((crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal('int')),), gc_scope_top_level())
+    
+    sequence = crep.cpp_sequence(value_obj,  # type: ignore
+                                 crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal('int')),
+                                 gc_scope_top_level())
+    node.rep = sequence  # type: ignore
+    as_root = q.get_as_ROOT(node)
+
+    assert isinstance(as_root, rh.cpp_ttree_rep)

--- a/tests/xAODlib/test_query_ast_visitor.py
+++ b/tests/xAODlib/test_query_ast_visitor.py
@@ -81,9 +81,22 @@ def test_as_root_rep_already_set():
 def test_as_root_as_dict():
     q = query_ast_visitor()
     node = ast.parse('1/1')
-    dict_obj = crep.cpp_dict({ast.Constant(value='hi'): crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal(int))}, gc_scope_top_level())
+    dict_obj = crep.cpp_dict({ast.Constant(value='hi'): crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal('int'))}, gc_scope_top_level())
     sequence = crep.cpp_sequence(dict_obj,  # type: ignore
-                                 crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal(int)),
+                                 crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal('int')),
+                                 gc_scope_top_level())
+    node.rep = sequence  # type: ignore
+    as_root = q.get_as_ROOT(node)
+
+    assert isinstance(as_root, rh.cpp_ttree_rep)
+
+
+def test_as_root_as_single_column():
+    q = query_ast_visitor()
+    node = ast.parse('1/1')
+    value_obj = crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal('int'))
+    sequence = crep.cpp_sequence(value_obj,
+                                 crep.cpp_value('i', gc_scope_top_level(), ctyp.terminal('int')),
                                  gc_scope_top_level())
     node.rep = sequence  # type: ignore
     as_root = q.get_as_ROOT(node)


### PR DESCRIPTION
Fixes #99
Fixes #98

- A single column can automatically be rendered as a ROOT file
- A sequence of tuples can automatically be rendered in a ROOT file
- Improve errror messages

Note; `qastle` considers lists and tuples to be the same, so this also complete support for lists.