### PR TITLE
Fix cmake warning about lack of project macro

### DIFF
--- a/func_adl_xAOD/R21Code/runner.sh
+++ b/func_adl_xAOD/R21Code/runner.sh
@@ -62,6 +62,7 @@ if [ $compile = 1 ]; then
 #
 # Project configuration for UserAnalysis.
 #
+project(func_adl_ntupler)
 
 # Set the minimum required CMake version:
 cmake_minimum_required( VERSION 3.4 FATAL_ERROR )


### PR DESCRIPTION
Fixes #88

- Add a `project` macro to the top level `CMakeLists.txt`, as required by `cmake`.