### PR TITLE
Minor Fixes to get CMS/xAOD codegen running

### DIFF
--- a/func_adl_xAOD/cms/aod/executor.py
+++ b/func_adl_xAOD/cms/aod/executor.py
@@ -6,7 +6,7 @@ from func_adl_xAOD.common.executor import executor
 
 class cms_aod_executor(executor):
     def __init__(self):
-        file_names = ['analyzer_cfg.py', 'Analyzer.cc', 'BuildFile.xml', 'runner.sh']
+        file_names = ['analyzer_cfg.py', 'Analyzer.cc', 'BuildFile.xml', "copy_root_tree.C", 'runner.sh']
         runner_name = 'runner.sh'
         template_dir_name = 'func_adl_xAOD/template/cms/r5'
         super().__init__(file_names, runner_name, template_dir_name, ec().get_method_names())

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -1029,8 +1029,8 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         self._gc.add_statement(statement.block())
 
         element_type = ctyp.terminal("int")
-        begin_value = crep.cpp_variable(unique_name("begin"), self._gc.current_scope(), element_type, initial_value=self.get_rep(lower_bound))
-        end_value = crep.cpp_variable(unique_name("end"), self._gc.current_scope(), element_type, initial_value=self.get_rep(upper_bound))
+        begin_value = crep.cpp_variable(unique_name("begin"), self._gc.current_scope(), element_type, initial_value=self.get_rep(lower_bound))  # type: ignore
+        end_value = crep.cpp_variable(unique_name("end"), self._gc.current_scope(), element_type, initial_value=self.get_rep(upper_bound))  # type: ignore
         self._gc.declare_variable(begin_value)
         self._gc.declare_variable(end_value)
 
@@ -1056,7 +1056,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         self._gc.add_statement(statement.arbitrary_statement(self.get_rep(c).as_cpp()))
 
         seq = self.make_sequence_from_collection(vector_value)
-        node.rep = seq
+        node.rep = seq  # type: ignore
         self._result = seq
         return seq
 

--- a/func_adl_xAOD/template/cms/r5/analyzer_cfg.py
+++ b/func_adl_xAOD/template/cms/r5/analyzer_cfg.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
+
 import FWCore.ParameterSet.Config as cms  # type: ignore
+import os
 
 process = cms.Process("Demo")
 
@@ -7,7 +9,7 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 
 process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(-1))
 
-filelistPath = '/scripts/filelist.txt'
+filelistPath = os.path.dirname(__file__) + '/filelist.txt'
 fileNames = tuple(['file:{0}'.format(line) for line in open(filelistPath, 'r').readlines()])
 
 process.source = cms.Source("PoolSource",

--- a/func_adl_xAOD/template/cms/r5/analyzer_cfg.py
+++ b/func_adl_xAOD/template/cms/r5/analyzer_cfg.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import FWCore.ParameterSet.Config as cms  # type: ignore
+import os
 
 process = cms.Process("Demo")
 
@@ -21,8 +22,10 @@ process.source = cms.Source("PoolSource",
 process.demo = cms.EDAnalyzer('Analyzer'
                               )
 
+output_file = os.environ['CMS_OUTPUT_FILE']
+
 process.TFileService = cms.Service("TFileService",
-                                   fileName=cms.string('/results/ANALYSIS.root')
+                                   fileName=cms.string(output_file)
                                    )
 
 process.p = cms.Path(process.demo)

--- a/func_adl_xAOD/template/cms/r5/analyzer_cfg.py
+++ b/func_adl_xAOD/template/cms/r5/analyzer_cfg.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import FWCore.ParameterSet.Config as cms  # type: ignore
-import os
 
 process = cms.Process("Demo")
 
@@ -9,7 +8,7 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 
 process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(-1))
 
-filelistPath = os.path.dirname(__file__) + '/filelist.txt'
+filelistPath = 'filelist.txt'
 fileNames = tuple(['file:{0}'.format(line) for line in open(filelistPath, 'r').readlines()])
 
 process.source = cms.Source("PoolSource",

--- a/func_adl_xAOD/template/cms/r5/copy_root_tree.C
+++ b/func_adl_xAOD/template/cms/r5/copy_root_tree.C
@@ -1,0 +1,28 @@
+void copy_root_tree(const char* input_name, const char* output_name)
+{
+  TFile *f_in = new TFile(input_name, "READ");
+  TFile *f_out = new TFile(output_name, "RECREATE");
+
+  f_in->cd("demo");
+  TDirectory *d_current = gDirectory;
+  TIter next(gDirectory->GetListOfKeys());
+  TKey *key;
+  while ((key=(TKey*)next())) {
+    if (TString(key->GetClassName()) == "TTree") {
+      cout << "Processing " << key->GetName() << endl;
+
+      // Get the old TTree from the old file (make sure the cwd is as expected)
+      d_current->cd();
+      TTree *t;
+      gDirectory->GetObject(key->GetName(), t);
+
+      // Write it out to the new file.
+      f_out->cd();
+      t->CloneTree()->Write();
+    }
+  }
+
+  f_out->Write();
+  f_out->Close();
+  f_in->Close();
+}

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -13,9 +13,11 @@ mkedanlzr Analyzer
 cd Analyzer
 
 ## Copy the Analyzer files to the Analyzer
-cp /scripts/Analyzer.cc ./src/
-cp /scripts/analyzer_cfg.py .
-cp /scripts/BuildFile.xml .
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cp $DIR/Analyzer.cc ./src/
+cp $DIR/analyzer_cfg.py .
+cp $DIR/BuildFile.xml .
 
 ## build the HiggsDemoAnalyzer
 scram b

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -101,7 +101,7 @@ if [ $run = 1 ]; then
     # Convert the ROOT file into the proper format.
     # CMS writes the tuples one directory down rather than in the top level.
     # Perhaps there is a more efficient way to solve this?
-    if [ $cmd == "cp"]; then
+    if [ $cmd == "cp" ]; then
         cvt='root -b -l -q /generated/copy_root_tree.C\(\"./$CMS_OUTPUT_FILE\",\"$destination\"\)'
         eval $cvt
     else

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 set -e
-
 set -x
+
+# Setup the CMS software (normally done automatically, but not for ServiceX)
+. /opt/cms/entrypoint.sh; 
 
 ## Create a subdir for the analysis
 mkdir analysis

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -64,7 +64,7 @@ if [ $compile = 1 ]; then
     ## build the analyzer
     scram b
 else
-    cd Analyzer
+    cd analysis/Analyzer
 fi
 
 # Run the analysis

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -69,16 +69,25 @@ fi
 
 # Run the analysis
 if [ $run = 1 ]; then
-   if [ "$input_method" == "filelist" ]; then
-      if [ -e $DIR/filelist.txt ]; then
-         cp $DIR/filelist.txt .
-      else
-         cp $local/filelist.txt .
-      fi
-   elif [ "$input_method" == "cmd" ]; then
-      echo $input_file > filelist.txt
-   fi
+    # Figure out the input file
+    if [ "$input_method" == "filelist" ]; then
+        if [ -e $DIR/filelist.txt ]; then
+            cp $DIR/filelist.txt .
+        else
+            cp $local/filelist.txt .
+        fi
+    elif [ "$input_method" == "cmd" ]; then
+        echo $input_file > filelist.txt
+    fi
 
-    ## run the analysis
+    # Figure out the output file
+    if [ $output_method == "cp" ]; then
+        destination=$output_dir
+    else
+        destination=$1
+    fi
+    export CMS_OUTPUT_FILE=$destination
+
+    # run the analysis
     cmsRun analyzer_cfg.py
 fi

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -3,26 +3,82 @@
 set -e
 set -x
 
+# Parse the command line arguments. Our defaults
+output_method="cp"
+output_dir="/results"
+input_method="filelist"
+input_file=""
+compile=1
+run=1
+
+while getopts "d:o:cr" opt; do
+    case "$opt" in
+    d)
+        input_method="cmd"
+        input_file=$OPTARG
+        ;;
+    c)
+        run=0
+        ;;
+    r)
+        compile=0
+        ;;
+    o)
+        output_dir=$OPTARG
+        ;;
+    ?)
+        exit 10
+    esac
+done
+
+# If there are any arguments left over, then very bad things have happened.
+shift $((OPTIND-1))
+if [ $# != 0 ]; then
+  echo "Extra arguments on the command line $@"
+  exit 1
+fi
+
 # Setup the CMS software (normally done automatically, but not for ServiceX)
 . /opt/cms/entrypoint.sh; 
 
-## Create a subdir for the analysis
-mkdir analysis
-cd analysis
-
-## Create the ED Analyzer package
-mkedanlzr Analyzer
-cd Analyzer
-
-## Copy the Analyzer files to the Analyzer
+## Get the location of this script, and, hence where we are going to be doing things.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+local=`pwd`
 
-cp $DIR/Analyzer.cc ./src/
-cp $DIR/analyzer_cfg.py .
-cp $DIR/BuildFile.xml .
+# Build the analysis is need be
+if [ $compile = 1 ]; then
 
-## build the HiggsDemoAnalyzer
-scram b
+    ## Create a subdir for the analysis
+    mkdir analysis
+    cd analysis
 
-## run the analysis
-cmsRun analyzer_cfg.py
+    ## Create the ED Analyzer package
+    mkedanlzr Analyzer
+    cd Analyzer
+
+
+    cp $DIR/Analyzer.cc ./src/
+    cp $DIR/analyzer_cfg.py .
+    cp $DIR/BuildFile.xml .
+
+    ## build the analyzer
+    scram b
+else
+    cd Analyzer
+fi
+
+# Run the analysis
+if [ $run = 1 ]; then
+   if [ "$input_method" == "filelist" ]; then
+      if [ -e $DIR/filelist.txt ]; then
+         cp $DIR/filelist.txt .
+      else
+         cp $local/filelist.txt .
+      fi
+   elif [ "$input_method" == "cmd" ]; then
+      echo $input_file > filelist.txt
+   fi
+
+    ## run the analysis
+    cmsRun analyzer_cfg.py
+fi

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -39,7 +39,9 @@ if [ $# != 0 ]; then
 fi
 
 # Setup the CMS software (normally done automatically, but not for ServiceX)
-. /opt/cms/entrypoint.sh; 
+if [ -z "$CVSROOT" ]; then
+    . /opt/cms/entrypoint.sh; 
+fi
 
 ## Get the location of this script, and, hence where we are going to be doing things.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -91,12 +93,12 @@ if [ $run = 1 ]; then
          cmd="xrdcp"
       fi
     fi
-    export CMS_OUTPUT_FILE=analysis_output.root
+    export CMS_OUTPUT_FILE=ANALYSIS.root
 
     # run the analysis
     cmsRun analyzer_cfg.py
 
     # And copy out the thing
     # TODO: why doesn't cms deal with the very long filename we give it?
-    $cmd /home/atlas/CMSSW_5_3_32/src/analysis/Analyzer/analysis_output.root $destination
+    $cmd ./$CMS_OUTPUT_FILE $destination
 fi

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -83,11 +83,20 @@ if [ $run = 1 ]; then
     # Figure out the output file
     if [ $output_method == "cp" ]; then
         destination=$output_dir
+        cmd="cp"
     else
         destination=$1
+      cmd="cp"
+      if [[ $destination == "root:"* ]]; then
+         cmd="xrdcp"
+      fi
     fi
-    export CMS_OUTPUT_FILE=$destination
+    export CMS_OUTPUT_FILE=analysis_output.root
 
     # run the analysis
     cmsRun analyzer_cfg.py
+
+    # And copy out the thing
+    # TODO: why doesn't cms deal with the very long filename we give it?
+    $cmd /home/atlas/CMSSW_5_3_32/src/analysis/Analyzer/analysis_output.root $destination
 fi

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -98,7 +98,15 @@ if [ $run = 1 ]; then
     # run the analysis
     cmsRun analyzer_cfg.py
 
-    # And copy out the thing
-    # TODO: why doesn't cms deal with the very long filename we give it?
-    $cmd ./$CMS_OUTPUT_FILE $destination
+    # Convert the ROOT file into the proper format.
+    # CMS writes the tuples one directory down rather than in the top level.
+    # Perhaps there is a more efficient way to solve this?
+    if [ $cmd == "cp"]; then
+        cvt='root -b -l -q /generated/copy_root_tree.C\(\"./$CMS_OUTPUT_FILE\",\"$destination\"\)'
+        eval $cvt
+    else
+        cvt='root -b -l -q /generated/copy_root_tree.C\(\"./$CMS_OUTPUT_FILE\",\"temp-output.root\"\)'
+        eval $cvt
+        $cmd ./temp-output.root $destination
+    fi
 fi

--- a/tests/cms/aod/utils.py
+++ b/tests/cms/aod/utils.py
@@ -1,26 +1,22 @@
 import ast
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 import awkward as ak
 import pandas as pd
 import uproot
-from func_adl import EventDataset
 from func_adl.object_stream import ObjectStream
 from func_adl_xAOD.cms.aod.executor import cms_aod_executor
 from func_adl_xAOD.cms.aod.query_ast_visitor import cms_aod_query_ast_visitor
 from func_adl_xAOD.common.cpp_representation import cpp_sequence, cpp_variable
 from func_adl_xAOD.common.util_scope import top_level_scope
 from tests.utils.base import LocalFile, dataset, dummy_executor
-from tests.utils.general import get_lines_of_code, print_lines
-from tests.utils.locators import (find_line_numbers_with, find_line_with,
-                                  find_next_closing_bracket, find_open_blocks)
 
 
 class cms_aod_dummy_executor(dummy_executor):
     def __init__(self):
         super().__init__()
-    
+
     def get_executor_obj(self) -> cms_aod_executor:
         return cms_aod_executor()
 
@@ -44,7 +40,7 @@ class CMSAODDockerException(Exception):
 class CMSAODLocalFile(LocalFile):
     def __init__(self, local_files: Union[Path, List[Path]]):
         super().__init__("cmsopendata/cmssw_5_3_32", "Analyzer.cc", local_files)
-    
+
     def raise_docker_exception(self, message: str):
         raise CMSAODDockerException(message)
 
@@ -65,9 +61,10 @@ async def exe_from_qastle(q: str):
     file.rep = cpp_sequence(iterator, iterator, top_level_scope())  # type: ignore
 
     # Use the dummy executor to process this, and return it.
-    exe = dummy_executor()
+    exe = dummy_executor()  # type: ignore
     exe.evaluate(a)
     return exe
+
 
 def load_root_as_pandas(file: Path) -> pd.DataFrame:
     '''Given the result from a query as a ROOT file path, return

--- a/version_info.py
+++ b/version_info.py
@@ -5,4 +5,4 @@ version_func_adl_xaod = linked_version
 
 
 # Some common dependend items - helps keep the various setup files by putting it in here.
-version_func_adl = ">=2.2, <3.0a"
+version_func_adl = ">=2.2b1, <3.0a"


### PR DESCRIPTION
Collecting minor bugs we need to fix here

* Version numbers in the setup file weren't compatible with what is on pypi
* Various type and flake8 style fixes
* The runner.sh script doesn't know it is being run from a `/scripts` directory - make it location agnostic.
* Setup the CMS environment
* Added `runner.sh` compile/run logic
* Copy the output TTree to a new root file at the top level rather than in a `TDirectory`, as expected by downstream software.

Things that should be checked and, perhaps, fixed:

* [ ] When the framework runs it prints out a message every single event it processes. It should print out once every 1000.
* [x] For some reason output file can't be sent to the right location with a directory - so it is right now being written to a bogus file which is copied out by runner.sh.
* [x] Is there a way the TTree could end up at the root of the file, rather than in the `demo` folder? If not, we'll work around it downstream. But... it is a bit painful. Actually, the more I think about this, I do think this needs to be fixed. If we can't do it in the cms code, we'll have to run an after-burner that copies it into [another tree](https://root-forum.cern.ch/t/copy-tree-from-one-file-to-another-no-changes-in-between/8102).
* [x] Make sure all long-running test are a go