### PR TITLE
Update for CMS Run 1 AOD Higgs 4L Running

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,8 @@
 [run]
 branch = True
-omit = func_adl_xAOD/template/
+omit = 
+    func_adl_xAOD/template/*
+    test/*
 
 [report]
 exclude_lines =

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Lint with Flake8
       if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       run: |
-        flake8 --ignore=E501
+        flake8 --ignore=E501,W503
     - name: Test with pytest
       run: |
         python -m pytest -m "not atlas_xaod_runner and not cms_aod_runner"

--- a/func_adl_xAOD/cms/aod/event_collections.py
+++ b/func_adl_xAOD/cms/aod/event_collections.py
@@ -56,6 +56,14 @@ cms_aod_collections = [
         ],
         'container_type': cms_aod_event_collection_collection('reco::MuonCollection', 'reco::Muon')
     },
+    {
+        'function_name': "Vertex",
+        'include_files': [
+            "DataFormats/VertexReco/interface/Vertex.h",
+            "DataFormats/VertexReco/interface/VertexFwd.h"
+        ],
+        'container_type': cms_aod_event_collection_collection('reco::VertexCollection', 'reco::Vertex')
+    }
 ]
 
 

--- a/func_adl_xAOD/cms/aod/event_collections.py
+++ b/func_adl_xAOD/cms/aod/event_collections.py
@@ -62,7 +62,7 @@ cms_aod_collections = [
             "DataFormats/VertexReco/interface/Vertex.h",
             "DataFormats/VertexReco/interface/VertexFwd.h"
         ],
-        'container_type': cms_aod_event_collection_collection('reco::VertexCollection', 'reco::Vertex')
+        'container_type': cms_aod_event_collection_collection('reco::VertexCollection', 'reco::Vertex', is_element_pointer=False)
     }
 ]
 

--- a/func_adl_xAOD/cms/aod/event_collections.py
+++ b/func_adl_xAOD/cms/aod/event_collections.py
@@ -63,6 +63,15 @@ cms_aod_collections = [
             "DataFormats/VertexReco/interface/VertexFwd.h"
         ],
         'container_type': cms_aod_event_collection_collection('reco::VertexCollection', 'reco::Vertex', is_element_pointer=False)
+    },
+    {
+        'function_name': "GsfElectrons",
+        'include_files': [
+            'DataFormats/EgammaCandidates/interface/GsfElectron.h',
+            'DataFormats/GsfTrackReco/interface/GsfTrack.h',
+            'DataFormats/GsfTrackReco/interface/GsfTrackFwd.h'
+        ],
+        'container_type': cms_aod_event_collection_collection('reco::GsfElectronCollection', 'reco::GsfElectron')
     }
 ]
 
@@ -77,9 +86,18 @@ class cms_aod_event_collections(event_collections):
 
 
 ctyp.add_method_type_info("reco::Track", "hitPattern", ctyp.terminal('reco::HitPattern'))
-ctyp.add_method_type_info("reco::Muon", "hitPattern", ctyp.terminal('reco::HitPattern'))
+
 ctyp.add_method_type_info("reco::Muon", "globalTrack", ctyp.terminal('reco::Track', is_pointer=True))
+ctyp.add_method_type_info("reco::Muon", "hitPattern", ctyp.terminal('reco::HitPattern'))
+ctyp.add_method_type_info("reco::Muon", "isPFIsolationValid", ctyp.terminal('bool'))
 ctyp.add_method_type_info("reco::Muon", "isPFMuon", ctyp.terminal('bool'))
 ctyp.add_method_type_info("reco::Muon", "pfIsolationR04", ctyp.terminal('reco::MuonPFIsolation'))
-ctyp.add_variable_type_info("reco::MuonPFIsolation", "sumChargedHadronPt", ctyp.terminal('double'))
-ctyp.add_method_type_info("reco::Muon", "isPFIsolationValid", ctyp.terminal('bool'))
+
+ctyp.add_method_type_info("reco::GsfElectron", "gsfTrack", ctyp.terminal('reco::GsfTrack', is_pointer=True))
+ctyp.add_method_type_info("reco::GsfElectron", "isEB", ctyp.terminal('bool'))
+ctyp.add_method_type_info("reco::GsfElectron", "isEE", ctyp.terminal('bool'))
+ctyp.add_method_type_info("reco::GsfElectron", "passingPflowPreselection", ctyp.terminal('bool'))
+ctyp.add_method_type_info("reco::GsfElectron", "superCluster", ctyp.terminal('reco::SuperClusterRef', is_pointer=True))
+ctyp.add_method_type_info("reco::GsfElectron", "pfIsolationVariables", ctyp.terminal('reco::GsfElectron::PflowIsolationVariables'))
+
+ctyp.add_method_type_info("reco::GsfTrack", "trackerExpectedHitsInner", ctyp.terminal('reco::HitPattern'))  # reco::HitPattern is the expected return type

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -190,7 +190,12 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         node - if the node has a rep, just return
 
         '''
-        if not hasattr(node, 'rep'):
+        rep = getattr(node, 'rep', None)
+        if rep is not None:
+            if not self._gc.current_scope().starts_with(rep.scope()):
+                rep = None
+
+        if rep is None:
             FuncADLNodeVisitor.visit(self, node)
 
         # Lots of nodes never get a representation - like `ast.Name`, so we

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -683,7 +683,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
             raise Exception("Do not know how to take the index of type '{0}'".format(v.cpp_type()))
 
         index = self.get_rep(node.slice)
-        node.rep = crep.cpp_value("{0}.at({1})".format(v.as_cpp(), index.as_cpp()), self._gc.current_scope(), cpp_type=v.get_element_type())  # type: ignore
+        node.rep = crep.cpp_value(f"{v.as_cpp()}{'->' if v.is_pointer() else '.'}at({index.as_cpp()})", self._gc.current_scope(), cpp_type=v.get_element_type())  # type: ignore
         self._result = node.rep
 
     def visit_Index(self, node):

--- a/func_adl_xAOD/common/cpp_functions.py
+++ b/func_adl_xAOD/common/cpp_functions.py
@@ -2,6 +2,7 @@
 # equivalent in C++.
 import ast
 from collections import namedtuple
+from func_adl_xAOD.common.cpp_types import terminal
 
 
 class FunctionAST(ast.AST):
@@ -58,7 +59,7 @@ def add_function_mapping(python_name, cpp_name, include_files, return_type):
     return_type: C++ return type
     '''
     global functions_to_replace
-    functions_to_replace[python_name] = cpp_function(cpp_name, include_files if type(include_files) is list else [include_files, ], return_type)
+    functions_to_replace[python_name] = cpp_function(cpp_name, include_files if type(include_files) is list else [include_files, ], terminal(return_type))
 
 
 # The list of functions to do the replacement

--- a/func_adl_xAOD/common/cpp_types.py
+++ b/func_adl_xAOD/common/cpp_types.py
@@ -56,27 +56,11 @@ class collection (terminal):
         return self._element_type
 
 
-class tuple:
-    'Represents a value which is a collection of other types'
-
-    def __init__(self, type_list):
-        '''
-        Initialize a type list. The value consists of `len(type_list)` items, each
-        of the type held inside type_lits.
-
-        type_list:      tuple,etc., that we can iterate over to get the types.
-        '''
-        self._type_list = type_list
-
-    def __str__(self):
-        return "(" + ','.join(self._type_list) + ")"
-
 ###########################
 # Manage types
 
 
 g_method_type_dict = {}
-g_variable_type_dict = {}
 
 
 def add_method_type_info(type_string, method_name, t):
@@ -92,19 +76,6 @@ def add_method_type_info(type_string, method_name, t):
     g_method_type_dict[type_string][method_name] = t
 
 
-def add_variable_type_info(type_string, variable_name, t):
-    '''
-    Define a type for a variable
-
-    type_string         String of the object the variable is being accessed against
-    variable_name       Name of the object
-    t                   The type (terminal, collection, etc.) of variable
-    '''
-    if type_string not in g_variable_type_dict:
-        g_variable_type_dict[type_string] = {}
-    g_variable_type_dict[type_string][variable_name] = t
-
-
 def method_type_info(type_string, method_name):
     '''
     Return the type of the method's return value
@@ -115,13 +86,3 @@ def method_type_info(type_string, method_name):
         return None
     return g_method_type_dict[type_string][method_name]
 
-
-def variable_type_info(type_string, variable_name):
-    '''
-    Return the type of the variable
-    '''
-    if type_string not in g_variable_type_dict:
-        return None
-    if variable_name not in g_variable_type_dict[type_string]:
-        return None
-    return g_variable_type_dict[type_string][variable_name]

--- a/func_adl_xAOD/common/cpp_types.py
+++ b/func_adl_xAOD/common/cpp_types.py
@@ -85,4 +85,3 @@ def method_type_info(type_string, method_name):
     if method_name not in g_method_type_dict[type_string]:
         return None
     return g_method_type_dict[type_string][method_name]
-

--- a/func_adl_xAOD/common/event_collections.py
+++ b/func_adl_xAOD/common/event_collections.py
@@ -28,10 +28,10 @@ class event_collection_collection(event_collection_container):
     def __init__(self, type_name, element_name, is_type_pointer, is_element_pointer):
         event_collection_container.__init__(self, type_name, is_type_pointer)
         self._element_name = element_name
-        self._is_pointer = is_element_pointer
+        self._is_element_pointer = is_element_pointer
 
     def element_type(self):
-        return ctyp.terminal(self._element_name, is_pointer=self._is_pointer)
+        return ctyp.terminal(self._element_name, is_pointer=self._is_element_pointer)
 
     def dereference(self):
         'Return a new version of us that is not a pointer'

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -93,7 +93,7 @@ if [ $run = 1 ]; then
          cmd="xrdcp"
       fi
     fi
-    export CMS_OUTPUT_FILE=/results/ANALYSIS.root
+    export CMS_OUTPUT_FILE=ANALYSIS.root
 
     # run the analysis
     cmsRun analyzer_cfg.py

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -162,6 +162,20 @@ def test_nested_lambda_argument_name_with_monad():
     assert "->E()" in lines[l_push]
 
 
+def test_dict_simple_reference():
+    'Dictionary references should be resolved automatically'
+    r = atlas_xaod_dataset() \
+        .Select(lambda e: {'e_list': e.Electrons("Electrons"), 'm_list': e.Muons("Muons")}) \
+        .Select('lambda e: e.e_list.Select(lambda e: e.E())') \
+        .value()
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+    l_push = find_line_with('push_back', lines)
+    assert "->E()" in lines[l_push]
+    r = find_line_with('muon', lines, throw_if_not_found=False)
+    assert r == -1
+
+
 def test_result_awkward():
     # The following statement should be a straight sequence, not an array.
     r = atlas_xaod_dataset() \

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -176,6 +176,20 @@ def test_dict_simple_reference():
     assert r == -1
 
 
+def test_dict_simple_reference_prop_lookup():
+    'Dictionary references should be resolved automatically'
+    r = atlas_xaod_dataset() \
+        .Select(lambda e: {'e_list': e.Electrons("Electrons"), 'm_list': e.Muons("Muons")}) \
+        .Select(lambda e: e['e_list'].Select(lambda e: e.E())) \
+        .value()
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+    l_push = find_line_with('push_back', lines)
+    assert "->E()" in lines[l_push]
+    r = find_line_with('muon', lines, throw_if_not_found=False)
+    assert r == -1
+
+
 def test_result_awkward():
     # The following statement should be a straight sequence, not an array.
     r = atlas_xaod_dataset() \

--- a/tests/cms/aod/test_aod_executor.py
+++ b/tests/cms/aod/test_aod_executor.py
@@ -34,7 +34,7 @@ def test_complex_dict():
     print_lines(lines)
 
     find_line_with("globalTrack()->dx", lines)
-    find_line_with(".at(0)->position()", lines)
+    find_line_with("at(0).position()", lines)
 
 
 def test_2nd_order_lookup():
@@ -59,8 +59,11 @@ def test_2nd_order_lookup():
 
     # Make sure the vertex line isn't used after it goes out of scope
     vertex_decl_line = find_line_with('edm::Handle<reco::VertexCollection>', lines)
+
+    vertex_variable_name = lines[vertex_decl_line].split(' ')[-1].strip(';')
+
     closing_scope = find_next_closing_bracket(lines[vertex_decl_line:])
-    vertex_used_too_late = find_line_with('vertex', lines[vertex_decl_line + closing_scope:], throw_if_not_found=False)
+    vertex_used_too_late = find_line_with(vertex_variable_name, lines[vertex_decl_line + closing_scope:], throw_if_not_found=False)
     if vertex_used_too_late != -1:
         print('Here is where it is used and down')
         print_lines(lines[closing_scope + vertex_decl_line + vertex_used_too_late:])

--- a/tests/cms/aod/test_aod_executor.py
+++ b/tests/cms/aod/test_aod_executor.py
@@ -1,6 +1,7 @@
 from tests.utils.locators import find_line_with
-from tests.utils.general import get_lines_of_code
+from tests.utils.general import get_lines_of_code, print_lines
 from tests.cms.aod.utils import cms_aod_dataset
+from func_adl_xAOD.cms.aod import isNonnull
 
 # Tests that make sure the cms aod executor is working correctly
 
@@ -18,3 +19,19 @@ def test_Select_member_variable():
     lines = get_lines_of_code(r)
     _ = find_line_with(".sumChargedHadronPt", lines)
     assert find_line_with(".sumChargedHadronPt()", lines, throw_if_not_found=False) == -1
+
+
+def test_complex_dict():
+    'Seen to fail in the wild, so a test case to track'
+    r = cms_aod_dataset() \
+        .Select(lambda e: {"muons": e.Muons("muons"), "primvtx": e.Vertex("offlinePrimaryVertices")}) \
+        .Select(lambda i: i.muons
+                .Where(lambda m: isNonnull(m.globalTrack()))
+                .Select(lambda m: m.globalTrack().dx(i.primvtx[0].position()))
+                ) \
+        .value()
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+
+    find_line_with("globalTrack()->dx", lines)
+    find_line_with(".at(0)->position()", lines)

--- a/tests/cms/aod/test_aod_executor.py
+++ b/tests/cms/aod/test_aod_executor.py
@@ -43,11 +43,11 @@ def test_2nd_order_lookup():
          .Select(lambda e: {"m": e.Muons("muons"), "p": e.Vertex("offlinePrimaryVertices")[0].position()})
          .Select(lambda i:
                  i.m
-                 .Where(lambda m: m.isPFMuon()
-                        and m.isPFIsolationValid()
-                        and isNonnull(m.globalTrack())
-                        and abs((m.globalTrack()).dxy(i.p)) < 0.5
-                        and abs((m.globalTrack()).dz(i.p)) < 1.
+                 .Where(lambda m: m.isPFMuon() and
+                        m.isPFIsolationValid() and
+                        isNonnull(m.globalTrack())
+                        abs((m.globalTrack()).dxy(i.p)) < 0.5 and
+                        abs((m.globalTrack()).dz(i.p)) < 1. and
                         )
                  .Select(lambda m: m.p()),
                  )

--- a/tests/cms/aod/test_aod_executor.py
+++ b/tests/cms/aod/test_aod_executor.py
@@ -43,11 +43,11 @@ def test_2nd_order_lookup():
          .Select(lambda e: {"m": e.Muons("muons"), "p": e.Vertex("offlinePrimaryVertices")[0].position()})
          .Select(lambda i:
                  i.m
-                 .Where(lambda m: m.isPFMuon() and
-                        m.isPFIsolationValid() and
-                        isNonnull(m.globalTrack())
-                        abs((m.globalTrack()).dxy(i.p)) < 0.5 and
-                        abs((m.globalTrack()).dz(i.p)) < 1. and
+                 .Where(lambda m: m.isPFMuon()
+                        and m.isPFIsolationValid()
+                        and isNonnull(m.globalTrack())
+                        and abs((m.globalTrack()).dxy(i.p)) < 0.5
+                        and abs((m.globalTrack()).dz(i.p)) < 1.
                         )
                  .Select(lambda m: m.p()),
                  )


### PR DESCRIPTION
These are a series of small fixes and feature updates to get the system ready for the CMS Run 1 Higgs to 4L backend

* Enable inline `dict` resolution, like what existed already in the `uproot` backend
* Fix bug in the return type for functions
* Fix bug in scoping of previously resolved representations
* Added a few new types and collections
* Added ability to tell the difference between an object that is a pointer, and is a flat-out object (particularly useful for Handle like objects in CMS).
* Some improvements to the code coverage measurements we are making