### PR TITLE
Fix up how `rep` is used and set

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,27 @@ on:
   - cron:  '1 0 * * *'
 
 jobs:
+  flake8:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install git+https://github.com/iris-hep/ast-language.git@e6470deb68529e1885a4bc46f781e2fe43a6f4c8
+        pip install --no-cache-dir -e .[test]
+        pip list
+    - name: Lint with Flake8
+      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      run: |
+        flake8 --ignore=E501,W503
+
   test:
 
     strategy:
@@ -15,6 +36,7 @@ jobs:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.platform }}
+    needs: flake8
 
     steps:
     - uses: actions/checkout@master

--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -78,8 +78,8 @@ class dummy_ast(ast.AST):
     'A dummy ast'
     _fields = tuple()
 
-    def __init__(self, rep=None):
-        self.rep = rep
+    def __init__(self, node: cpp_rep_base):
+        set_rep(self, node)
 
 
 class cpp_rep_base:
@@ -290,3 +290,17 @@ class cpp_sequence(cpp_rep_base):
     def scope(self) -> Union[gc_scope, gc_scope_top_level]:
         'Return scope where this sequence was created/valid'
         return self._scope
+
+
+def set_rep(node: ast.AST, value: cpp_rep_base):
+    '''
+    Set the representation of a node to a value.
+    '''
+    node.rep = value  # type: ignore
+
+
+def get_rep(node: ast.AST) -> cpp_rep_base:
+    '''
+    Get the representation of a node.
+    '''
+    return node.rep  # type: ignore

--- a/func_adl_xAOD/common/executor.py
+++ b/func_adl_xAOD/common/executor.py
@@ -118,7 +118,7 @@ class executor(ABC):
         from func_adl import find_EventDataset
         file = find_EventDataset(ast)
         iterator = crep.cpp_variable("bogus-do-not-use", top_level_scope(), cpp_type=None)
-        file.rep = crep.cpp_sequence(iterator, iterator, top_level_scope())  # type: ignore
+        crep.set_rep(file, crep.cpp_sequence(iterator, iterator, top_level_scope()))
 
         # Visit the AST to generate the code structure and find out what the
         # result is going to be.

--- a/func_adl_xAOD/common/utils.py
+++ b/func_adl_xAOD/common/utils.py
@@ -1,3 +1,5 @@
+import ast
+from func_adl_xAOD.common.cpp_representation import cpp_rep_base
 from typing import Dict, List
 
 import func_adl_xAOD.common.cpp_types as ctyp

--- a/func_adl_xAOD/common/utils.py
+++ b/func_adl_xAOD/common/utils.py
@@ -1,5 +1,3 @@
-import ast
-from func_adl_xAOD.common.cpp_representation import cpp_rep_base
 from typing import Dict, List
 
 import func_adl_xAOD.common.cpp_types as ctyp

--- a/tests/atlas/xaod/test_query_ast_visitor.py
+++ b/tests/atlas/xaod/test_query_ast_visitor.py
@@ -12,8 +12,7 @@ from tests.atlas.xaod.utils import ast_parse_with_replacement
 
 def test_binary_plus_return_type_1():
     q = atlas_xaod_query_ast_visitor()
-    q.visit(ast.parse('1+1.2'))
-    r = q._result
+    r = q.get_rep(ast.parse('1+1.2').body[0].value)  # type: ignore
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'
@@ -21,8 +20,7 @@ def test_binary_plus_return_type_1():
 
 def test_binary_plus_return_type_2():
     q = atlas_xaod_query_ast_visitor()
-    q.visit(ast.parse('1.2+1'))
-    r = q._result
+    r = q.get_rep(ast.parse('1.2+1').body[0].value)
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'
@@ -30,8 +28,7 @@ def test_binary_plus_return_type_2():
 
 def test_binary_plus_return_type_3():
     q = atlas_xaod_query_ast_visitor()
-    q.visit(ast.parse('1+1'))
-    r = q._result
+    r = q.get_rep(ast.parse('1+1').body[0].value)
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'int'
@@ -39,8 +36,7 @@ def test_binary_plus_return_type_3():
 
 def test_binary_mult_return_type_1():
     q = atlas_xaod_query_ast_visitor()
-    q.visit(ast.parse('1.2*1'))
-    r = q._result
+    r = q.get_rep(ast.parse('1.2*1').body[0].value)
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'
@@ -48,8 +44,7 @@ def test_binary_mult_return_type_1():
 
 def test_binary_mult_return_type_2():
     q = atlas_xaod_query_ast_visitor()
-    q.visit(ast.parse('1*1'))
-    r = q._result
+    r = q.get_rep(ast.parse('1*1').body[0].value)
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'int'
@@ -57,8 +52,7 @@ def test_binary_mult_return_type_2():
 
 def test_binary_divide_return_type_1():
     q = atlas_xaod_query_ast_visitor()
-    q.visit(ast.parse('1.2/1'))
-    r = q._result
+    r = q.get_rep(ast.parse('1.2/1').body[0].value)
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'
@@ -66,8 +60,7 @@ def test_binary_divide_return_type_1():
 
 def test_binary_divide_return_type_2():
     q = atlas_xaod_query_ast_visitor()
-    q.visit(ast.parse('1/1'))
-    r = q._result
+    r = q.get_rep(ast.parse('1/1').body[0].value)
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'

--- a/tests/atlas/xaod/test_query_ast_visitor.py
+++ b/tests/atlas/xaod/test_query_ast_visitor.py
@@ -20,7 +20,7 @@ def test_binary_plus_return_type_1():
 
 def test_binary_plus_return_type_2():
     q = atlas_xaod_query_ast_visitor()
-    r = q.get_rep(ast.parse('1.2+1').body[0].value)
+    r = q.get_rep(ast.parse('1.2+1').body[0].value)  # type: ignore
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'
@@ -28,7 +28,7 @@ def test_binary_plus_return_type_2():
 
 def test_binary_plus_return_type_3():
     q = atlas_xaod_query_ast_visitor()
-    r = q.get_rep(ast.parse('1+1').body[0].value)
+    r = q.get_rep(ast.parse('1+1').body[0].value)  # type: ignore
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'int'
@@ -36,7 +36,7 @@ def test_binary_plus_return_type_3():
 
 def test_binary_mult_return_type_1():
     q = atlas_xaod_query_ast_visitor()
-    r = q.get_rep(ast.parse('1.2*1').body[0].value)
+    r = q.get_rep(ast.parse('1.2*1').body[0].value)  # type: ignore
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'
@@ -44,7 +44,7 @@ def test_binary_mult_return_type_1():
 
 def test_binary_mult_return_type_2():
     q = atlas_xaod_query_ast_visitor()
-    r = q.get_rep(ast.parse('1*1').body[0].value)
+    r = q.get_rep(ast.parse('1*1').body[0].value)  # type: ignore
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'int'
@@ -52,7 +52,7 @@ def test_binary_mult_return_type_2():
 
 def test_binary_divide_return_type_1():
     q = atlas_xaod_query_ast_visitor()
-    r = q.get_rep(ast.parse('1.2/1').body[0].value)
+    r = q.get_rep(ast.parse('1.2/1').body[0].value)  # type: ignore
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'
@@ -60,7 +60,7 @@ def test_binary_divide_return_type_1():
 
 def test_binary_divide_return_type_2():
     q = atlas_xaod_query_ast_visitor()
-    r = q.get_rep(ast.parse('1/1').body[0].value)
+    r = q.get_rep(ast.parse('1/1').body[0].value)  # type: ignore
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'

--- a/tests/atlas/xaod/test_query_ast_visitor.py
+++ b/tests/atlas/xaod/test_query_ast_visitor.py
@@ -4,6 +4,7 @@ import ast
 import func_adl_xAOD.common.cpp_representation as crep
 import func_adl_xAOD.common.cpp_types as ctyp
 import func_adl_xAOD.common.result_ttree as rh
+import pytest
 from func_adl_xAOD.atlas.xaod.query_ast_visitor import \
     atlas_xaod_query_ast_visitor
 from func_adl_xAOD.common.util_scope import gc_scope_top_level
@@ -125,3 +126,14 @@ def test_subscript():
     assert isinstance(as_root, crep.cpp_value)
     assert as_root.cpp_type() == 'int'
     assert as_root.as_cpp() == 'jets.at(10)'
+
+
+def test_name():
+    'This should fail b.c. name never gets a rep'
+    q = atlas_xaod_query_ast_visitor()
+    n = ast.Name(id='a')
+
+    with pytest.raises(Exception) as e:
+        q.get_rep(n)
+
+    assert 'Internal' in str(e)

--- a/tests/atlas/xaod/utils.py
+++ b/tests/atlas/xaod/utils.py
@@ -9,7 +9,7 @@ from func_adl.object_stream import ObjectStream
 from func_adl_xAOD.atlas.xaod.executor import atlas_xaod_executor
 from func_adl_xAOD.atlas.xaod.query_ast_visitor import \
     atlas_xaod_query_ast_visitor
-from func_adl_xAOD.common.cpp_representation import cpp_sequence, cpp_variable
+from func_adl_xAOD.common.cpp_representation import cpp_sequence, cpp_variable, set_rep
 from func_adl_xAOD.common.util_scope import top_level_scope
 from tests.utils.base import LocalFile, dataset, dummy_executor
 
@@ -59,7 +59,7 @@ async def exe_from_qastle(q: str):
     from func_adl import find_EventDataset
     file = find_EventDataset(a)
     iterator = cpp_variable("bogus-do-not-use", top_level_scope(), cpp_type=None)
-    file.rep = cpp_sequence(iterator, iterator, top_level_scope())  # type: ignore
+    set_rep(file, cpp_sequence(iterator, iterator, top_level_scope()))
 
     # Use the dummy executor to process this, and return it.
     exe = atlas_xaod_dummy_executor()

--- a/tests/cms/aod/utils.py
+++ b/tests/cms/aod/utils.py
@@ -8,7 +8,7 @@ import uproot
 from func_adl.object_stream import ObjectStream
 from func_adl_xAOD.cms.aod.executor import cms_aod_executor
 from func_adl_xAOD.cms.aod.query_ast_visitor import cms_aod_query_ast_visitor
-from func_adl_xAOD.common.cpp_representation import cpp_sequence, cpp_variable
+from func_adl_xAOD.common.cpp_representation import cpp_sequence, cpp_variable, set_rep
 from func_adl_xAOD.common.util_scope import top_level_scope
 from tests.utils.base import LocalFile, dataset, dummy_executor
 
@@ -58,7 +58,7 @@ async def exe_from_qastle(q: str):
     from func_adl import find_EventDataset
     file = find_EventDataset(a)
     iterator = cpp_variable("bogus-do-not-use", top_level_scope(), cpp_type=None)
-    file.rep = cpp_sequence(iterator, iterator, top_level_scope())  # type: ignore
+    set_rep(file, cpp_sequence(iterator, iterator, top_level_scope()))
 
     # Use the dummy executor to process this, and return it.
     exe = dummy_executor()  # type: ignore

--- a/tests/utils/base.py
+++ b/tests/utils/base.py
@@ -15,7 +15,7 @@ from func_adl_xAOD.common.result_ttree import cpp_ttree_rep
 from func_adl_xAOD.common.executor import executor
 from func_adl_xAOD.common.ast_to_cpp_translator import query_ast_visitor
 from func_adl_xAOD.common.util_scope import top_level_scope
-from func_adl_xAOD.common.cpp_representation import cpp_sequence, cpp_variable
+from func_adl_xAOD.common.cpp_representation import cpp_sequence, cpp_variable, set_rep
 
 # Use this to turn on dumping of output and C++
 dump_running_log = True
@@ -186,7 +186,7 @@ class dataset(EventDataset, ABC):
         from func_adl import find_EventDataset
         file = find_EventDataset(a)
         iterator = cpp_variable("bogus-do-not-use", top_level_scope(), cpp_type=None)
-        file.rep = cpp_sequence(iterator, iterator, top_level_scope())  # type: ignore
+        set_rep(file, cpp_sequence(iterator, iterator, top_level_scope()))
 
         # Use the dummy executor to process this, and return it.
         exe = self.get_dummy_executor_obj()


### PR DESCRIPTION
* Streamline where `.rep` is checked for staleness (only one place needed)! (Fixes #163)
* Remove usage of `_result` (Fixes #167)
* Use methods to do set and get of the ast node's representation (Fixes #41)
* Fix up a bunch of flake8 errors
* Split up how we run CI so we do flake8 first, and then everything else after.