### PR TITLE
Better Testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
       run: |
         python -m pytest -m "not atlas_xaod_runner and not cms_aod_runner"
     - name: Report coverage with Codecov
-      if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -1016,11 +1016,10 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         new_sequence_var = w_val.copy_with_new_scope(self._gc.current_scope())
         crep.set_rep(node, crep.cpp_sequence(new_sequence_var, seq.iterator_value(), self._gc.current_scope()))
 
-    def call_Range(self, node: ast.AST, args: List[ast.AST]):
+    def call_Range(self, node: ast.Call, args: List[ast.AST]):
         'Create a collection of numbers from lower_bound'
 
-        if len(args) != 2:
-            raise Exception('blah blah')
+        assert len(args) == 2, 'Range(lower bound, upper bound) is the only allowed form'
         lower_bound = args[0]
         upper_bound = args[1]
 

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -802,6 +802,25 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
     def visit_Str(self, node):
         crep.set_rep(node, crep.cpp_value('"{0}"'.format(node.s), self._gc.current_scope(), ctyp.terminal("string")))
 
+    def visit_Constant(self, node: ast.Constant):
+        '''Visit Constnat node.
+
+        Note that this has to take the place of `visit_Str` and `visit_Num` as we roll
+        python versions forward. So those methods and this method must be kept in sync.
+
+        Args:
+            node (ast.Constant): The constant to visit
+        '''
+        value = node.value
+        if type(value) is str:
+            crep.set_rep(node, crep.cpp_value(f'"{value}"', self._gc.current_scope(), ctyp.terminal("string")))
+        elif type(value) is int:
+            crep.set_rep(node, crep.cpp_value(value, self._gc.current_scope(), ctyp.terminal("int")))
+        elif type(value) is float:
+            crep.set_rep(node, crep.cpp_value(value, self._gc.current_scope(), ctyp.terminal("double")))
+        else:
+            raise Exception(f"Unsupported constant type: {type(value)}")
+
     def code_fill_ttree(self, e_rep: crep.cpp_rep_base, e_name: crep.cpp_variable,
                         scope_fill: Union[gc_scope, gc_scope_top_level]) -> Union[gc_scope, gc_scope_top_level]:
         '''

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -32,7 +32,7 @@ class hash_event_dataset(EventDataset):
         return ExecutorInfo(f_spec.main_script, f_spec.result_rep.filename)
 
 
-@pytest.yield_fixture()
+@pytest.fixture()
 def cache_directory():
     'Return a directory that can be deleted when the test is done'
     with tempfile.TemporaryDirectory() as d_temp:

--- a/tests/atlas/xaod/test_integrated_query.py
+++ b/tests/atlas/xaod/test_integrated_query.py
@@ -33,7 +33,7 @@ def test_select_first_of_array():
     assert training_df.iloc[-1]['col1'] == 336
 
 
-@pytest.yield_fixture()
+@pytest.fixture()
 def event_loop():
     'Get the loop done right on windows'
     if os.name == 'nt':

--- a/tests/atlas/xaod/test_integrated_query.py
+++ b/tests/atlas/xaod/test_integrated_query.py
@@ -148,7 +148,7 @@ def test_1D_array():
                              .Select('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: j.pt()/1000.0)'))
     print(training_df)
     assert len(training_df[b'col1']) == 10
-    assert len(training_df[b'col1'][0]) == 32
+    assert len(training_df[b'col1'][0]) == 32  # type: ignore
 
 
 def test_2D_array():
@@ -157,8 +157,8 @@ def test_2D_array():
                              .Select('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: j.Jets("AntiKt4EMTopoJets").Select(lambda j1: j1.pt()/1000.0))'))
     print(training_df)
     assert len(training_df[b'col1']) == 10
-    assert len(training_df[b'col1'][0]) == 32
-    assert len(training_df[b'col1'][0][0]) == 32
+    assert len(training_df[b'col1'][0]) == 32  # type: ignore
+    assert len(training_df[b'col1'][0][0]) == 32  # type: ignore
 
 
 def test_2D_nested_where():
@@ -172,4 +172,4 @@ def test_2D_nested_where():
     print(training_df)
     a = training_df[b'col1']
     assert len(a) == 10
-    assert len(a[0]) == 8
+    assert len(a[0]) == 8  # type: ignore

--- a/tests/atlas/xaod/test_query_ast_visitor.py
+++ b/tests/atlas/xaod/test_query_ast_visitor.py
@@ -1,5 +1,6 @@
 # Some very direct white box testing
 import ast
+import sys
 
 import func_adl_xAOD.common.cpp_representation as crep
 import func_adl_xAOD.common.cpp_types as ctyp
@@ -25,6 +26,19 @@ def test_binary_plus_return_type_2():
 
     assert isinstance(r, crep.cpp_value)
     assert r.cpp_type().type == 'double'
+
+
+def test_complex_number_not_understood():
+    if sys.version_info >= (3, 8):
+        import cmath  # NOQA
+        c = complex(1, 2)
+        node = ast.Constant(value=c, kind=None)
+
+        q = atlas_xaod_query_ast_visitor()        
+        with pytest.raises(Exception) as e:
+            q.get_rep(node)
+
+        assert 'complex' in str(e)
 
 
 def test_binary_plus_return_type_3():

--- a/tests/atlas/xaod/test_query_ast_visitor.py
+++ b/tests/atlas/xaod/test_query_ast_visitor.py
@@ -34,7 +34,7 @@ def test_complex_number_not_understood():
         c = complex(1, 2)
         node = ast.Constant(value=c, kind=None)
 
-        q = atlas_xaod_query_ast_visitor()        
+        q = atlas_xaod_query_ast_visitor()
         with pytest.raises(Exception) as e:
             q.get_rep(node)
 


### PR DESCRIPTION
* Test `Range` during fast testing (code coverage) (Fixes #171)
* Add `ast.Constant` parsing to get rid of depreciation warnings for `ast.Str` and `ast.Num`. (Fixes #168)
* Update some `pytest` fixtures to get rid of test warnings