### PR TITLE
Add JobOptions Injection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,6 @@ jobs:
         pip install --no-cache-dir -e .[test]
         pip list
     - name: Lint with Flake8
-      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       run: |
         flake8 --ignore=E501,W503  --exclude=func_adl_xAOD/template
 
@@ -50,10 +49,6 @@ jobs:
         pip install git+https://github.com/iris-hep/ast-language.git@e6470deb68529e1885a4bc46f781e2fe43a6f4c8
         pip install --no-cache-dir -e .[test]
         pip list
-    - name: Lint with Flake8
-      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
-      run: |
-        flake8 --ignore=E501,W503
     - name: Test with pytest
       run: |
         python -m pytest -m "not atlas_xaod_runner and not cms_aod_runner"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Lint with Flake8
       if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       run: |
-        flake8 --ignore=E501,W503
+        flake8 --ignore=E501,W503  --exclude=func_adl_xAOD/template
 
   test:
 

--- a/func_adl_xAOD/atlas/xaod/executor.py
+++ b/func_adl_xAOD/atlas/xaod/executor.py
@@ -1,6 +1,6 @@
 import ast
 from func_adl_xAOD.atlas.xaod.event_collections import atlas_event_collection_coder, atlas_xaod_collections, define_default_atlas_types
-from typing import Callable
+from typing import Any, Callable, Dict
 from func_adl_xAOD.common.event_collections import EventCollectionSpecification
 from func_adl_xAOD.common.math_utils import get_math_methods
 from func_adl_xAOD.atlas.xaod.jets import get_jet_methods
@@ -31,6 +31,21 @@ class atlas_xaod_executor(executor):
 
     def get_visitor_obj(self):
         return atlas_xaod_query_ast_visitor()
+
+    def add_to_replacement_dict(self) -> Dict[str, Any]:
+        d1 = super().add_to_replacement_dict()
+
+        # Combine metadata script blocks
+        script_text = []
+        for md in self._job_option_blocks:
+            for ln in md.script:
+                script_text.append(ln)
+
+        d = {
+            'job_option_additions': script_text
+        }
+        d.update(d1)
+        return d
 
     def build_collection_callback(self, metadata: EventCollectionSpecification) -> Callable[[ast.Call], ast.Call]:
         '''Build the AST analyzer callback for this collection.

--- a/func_adl_xAOD/atlas/xaod/executor.py
+++ b/func_adl_xAOD/atlas/xaod/executor.py
@@ -1,4 +1,5 @@
 import ast
+from func_adl_xAOD.common.meta_data import generate_script_block
 from func_adl_xAOD.atlas.xaod.event_collections import atlas_event_collection_coder, atlas_xaod_collections, define_default_atlas_types
 from typing import Any, Callable, Dict
 from func_adl_xAOD.common.event_collections import EventCollectionSpecification
@@ -36,13 +37,8 @@ class atlas_xaod_executor(executor):
         d1 = super().add_to_replacement_dict()
 
         # Combine metadata script blocks
-        script_text = []
-        for md in self._job_option_blocks:
-            for ln in md.script:
-                script_text.append(ln)
-
         d = {
-            'job_option_additions': script_text
+            'job_option_additions': generate_script_block(self._job_option_blocks)
         }
         d.update(d1)
         return d

--- a/func_adl_xAOD/common/math_utils.py
+++ b/func_adl_xAOD/common/math_utils.py
@@ -18,7 +18,7 @@ DeltaRSpec = cpp_ast.CPPCodeSpecification(
 )
 
 
-def DeltaR(eta1, phi1, eta2, phi2):
+def DeltaR(eta1, phi1, eta2, phi2) -> float:
     'Calculate the DeltaR between two eta,phi specified vectors'
     raise NotImplementedError('DeltaR should never be called in python!')
 

--- a/func_adl_xAOD/template/atlas/r21/ATestRun_eljob.py
+++ b/func_adl_xAOD/template/atlas/r21/ATestRun_eljob.py
@@ -26,6 +26,10 @@ sh.printContent()
 job = ROOT.EL.Job()
 job.sampleHandler(sh)
 
+{% for i in job_option_additions %}
+{{i}}
+{% endfor %}
+
 # Commented out for now because it really slows things down. Uncomment and change
 # the bank to be Analysis_NOSYS in query.cxx and it will work again.
 # #Get the systematics tool in - because we need it.

--- a/func_adl_xAOD/template/atlas/r21/ATestRun_eljob.py
+++ b/func_adl_xAOD/template/atlas/r21/ATestRun_eljob.py
@@ -15,18 +15,16 @@ parser.add_option('-s', '--submission-dir', dest='submission_dir',
 (options, args) = parser.parse_args()
 
 
-# Set up the sample handler object. See comments from the C++ macro
-# for the details about these lines.
+# The sample handler is going to load the files form filelist.txt,
+# in this context, it is an embarrassingly easy use of that object.
 sh = ROOT.SH.SampleHandler()
 sh.setMetaString('nc_tree', 'CollectionTree')
-# ROOT.SH.ScanDir().filePattern( '{{df}}' ).scan( sh, inputFilePath )
 ROOT.SH.readFileList(sh, "ANALYSIS", "filelist.txt")
 sh.printContent()
 
 # Create an EventLoop job.
 job = ROOT.EL.Job()
 job.sampleHandler(sh)
-# job.options().setDouble( ROOT.EL.Job.optMaxEvents, 500 )
 
 # Commented out for now because it really slows things down. Uncomment and change
 # the bank to be Analysis_NOSYS in query.cxx and it will work again.

--- a/tests/atlas/xaod/test_atlas_xaod_exectuor.py
+++ b/tests/atlas/xaod/test_atlas_xaod_exectuor.py
@@ -63,3 +63,26 @@ def test_bad_ast_no_call_to_name(tmp_path):
         exe.write_cpp_files(exe.apply_ast_transformations(a), tmp_path)
 
     assert 'func_adl ast' in str(e.value)
+
+
+def test_md_job_options(tmp_path):
+    'Make sure our job options script appears in the right place'
+
+    # Get the ast to play with
+    a = (query_as_ast()
+         .MetaData({
+                   'metadata_type': 'add_job_script',
+                   'name': 'Vertex',
+                   'script': [
+                       '# this is a fork tester',
+                   ]
+                   })
+         .Select('lambda e: e.EventInfo("EventInfo").runNumber()')
+         .value())
+
+    exe = atlas_xaod_executor()
+    exe.write_cpp_files(exe.apply_ast_transformations(a), tmp_path)
+
+    with open(tmp_path / 'ATestRun_eljob.py', 'r') as f:
+        lines = [ln.strip() for ln in f.readlines()]
+        assert '# this is a fork tester' in lines

--- a/tests/atlas/xaod/test_integrated_query.py
+++ b/tests/atlas/xaod/test_integrated_query.py
@@ -27,10 +27,14 @@ def test_select_first_of_array():
     # The hard part is that First() here does not return a single item, but, rather, an array that
     # has to be aggregated over.
     training_df = as_pandas(f_single
-                            .Select('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: e.Tracks("InDetTrackParticles")).First().Count()'))
-    assert training_df.iloc[0]['col1'] == 1897
-    assert training_df.iloc[1]['col1'] == 605
-    assert training_df.iloc[-1]['col1'] == 336
+                            .Select(lambda e: e.Jets("AntiKt4EMTopoJets")
+                                    .Select(lambda _: e.Tracks("InDetTrackParticles"))
+                                    .First()
+                                    .Count())
+                            )
+    assert training_df.iloc[0]['col1'] == 394
+    assert training_df.iloc[1]['col1'] == 387
+    assert training_df.iloc[-1]['col1'] == 381
 
 
 @pytest.fixture()
@@ -48,12 +52,20 @@ def event_loop():
 async def test_two_simultaneous_runs():
     # Test the future return stuff
     f_training_df_1 = as_pandas_async(f_single
-                                      .Select('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: e.Tracks("InDetTrackParticles")).First().Count()'))
+                                      .Select(lambda e: e.Jets("AntiKt4EMTopoJets")
+                                              .Select(lambda j: e.Tracks("InDetTrackParticles"))
+                                              .First()
+                                              .Count())
+                                      )
     f_training_df_2 = as_pandas_async(f_single
-                                      .Select('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: e.Tracks("InDetTrackParticles")).First().Count()'))
+                                      .Select(lambda e: e.Jets("AntiKt4EMTopoJets")
+                                              .Select(lambda j: e.Tracks("InDetTrackParticles"))
+                                              .First()
+                                              .Count())
+                                      )
     r1, r2 = await asyncio.gather(f_training_df_1, f_training_df_2)
-    assert r1.iloc[0]['col1'] == 1897
-    assert r2.iloc[0]['col1'] == 1897
+    assert r1.iloc[0]['col1'] == 394
+    assert r2.iloc[0]['col1'] == 394
 
 
 def test_flatten_array():
@@ -61,7 +73,7 @@ def test_flatten_array():
     training_df = as_pandas(f_single
                             .SelectMany('lambda e: e.Jets("AntiKt4EMTopoJets")')
                             .Select('lambda j: j.pt()/1000.0'))
-    assert int(training_df.iloc[0]['col1']) == 257  # type: ignore
+    assert abs(training_df.iloc[0]['col1'] - 52.02462890625) < 0.001  # type: ignore ()
     assert int(training_df.iloc[0]['col1']) != int(training_df.iloc[1]['col1'])  # type: ignore
 
 
@@ -73,7 +85,75 @@ def test_simple_dict_output():
                                 'JetPt': j.pt() / 1000.0
                             }))
     print(training_df)
-    assert int(training_df.iloc[0]['JetPt']) == 257  # type: ignore
+    assert abs(training_df.iloc[0]['JetPt'] - 52.02462890625) < 0.001  # type: ignore ()
+    assert int(training_df.iloc[0]['JetPt']) != int(training_df.iloc[1]['JetPt'])  # type: ignore
+
+
+def test_md_job_options():
+    '''Run object corrections as we go
+    Based on the following code:
+
+
+    '''
+    training_df = as_pandas(f_single
+                            .MetaData({
+                                'metadata_type': 'add_job_script',
+                                'name': 'sys_error_tool',
+                                'script': [
+                                    "# Set up the systematics loader/handler service:",
+                                    "from AnaAlgorithm.DualUseConfig import createService",
+                                    "from AnaAlgorithm.AlgSequence import AlgSequence",
+                                    "calibrationAlgSeq = AlgSequence()",
+                                    "sysService = createService( 'CP::SystematicsSvc', 'SystematicsSvc', sequence = calibrationAlgSeq )",
+                                    "sysService.sigmaRecommended = 1",
+                                    "# Add sequence to job",
+                                ],
+                            })
+                            .MetaData({
+                                'metadata_type': 'add_job_script',
+                                'name': 'pileup_tool',
+                                'script': [
+                                    "from AsgAnalysisAlgorithms.PileupAnalysisSequence import makePileupAnalysisSequence",
+                                    "pileupSequence = makePileupAnalysisSequence( 'mc' )",
+                                    "pileupSequence.configure( inputName = 'EventInfo', outputName = 'EventInfo_%SYS%' )",
+                                    "# print( pileupSequence ) # For debugging",
+                                    "calibrationAlgSeq += pileupSequence",
+                                ],
+                                'depends_on': ['sys_error_tool']
+                            })
+                            .MetaData({
+                                'metadata_type': 'add_job_script',
+                                'name': 'jet_corrections',
+                                'script': [
+                                    "jetContainer = 'AntiKt4EMTopoJets'",
+                                    "from JetAnalysisAlgorithms.JetAnalysisSequence import makeJetAnalysisSequence",
+                                    "jetSequence = makeJetAnalysisSequence( 'mc', jetContainer, enableCutflow=True, enableKinematicHistograms=True )",
+                                    "jetSequence.configure( inputName = jetContainer, outputName = 'AnalysisJetsBase_%SYS%' )",
+                                    "calibrationAlgSeq += jetSequence",
+                                    "# print( jetSequence ) # For debugging",
+                                    "",
+                                    "# Include, and then set up the jet analysis algorithm sequence:",
+                                    "from JetAnalysisAlgorithms.JetJvtAnalysisSequence import makeJetJvtAnalysisSequence",
+                                    "jvtSequence = makeJetJvtAnalysisSequence( 'mc', jetContainer, enableCutflow=True )",
+                                    "jvtSequence.configure( inputName = { 'eventInfo' : 'EventInfo_%SYS%',",
+                                    "                                     'jets'      : 'AnalysisJetsBase_%SYS%' },",
+                                    "                       outputName = { 'jets'      : 'AnalysisJets_%SYS%' },",
+                                    "                       affectingSystematics = { 'jets' : jetSequence.affectingSystematics() } )",
+                                    "calibrationAlgSeq += jvtSequence",
+                                    "# print( jvtSequence ) # For debugging",
+                                    "calibrationAlgSeq.addSelfToJob( job )",  # TODO: Can I do this earlier?
+                                    "print(job) # for debugging",
+                                ],
+                                'depends_on': ['pileup_tool']
+                            })
+                            # TODO: get the sequence above running (add to the job)
+                            # TODO: Make sure we correct the proper container, and see if the jet energy changes as expected.
+                            .SelectMany(lambda e: e.Jets("AnalysisJets_NOSYS"))
+                            .Select(lambda j: {
+                                'JetPt': j.pt() / 1000.0
+                            }))
+    print(training_df)
+    assert abs(training_df.iloc[0]['JetPt'] - 50.10308984375) < 0.001  # type: ignore ()
     assert int(training_df.iloc[0]['JetPt']) != int(training_df.iloc[1]['JetPt'])  # type: ignore
 
 
@@ -83,7 +163,7 @@ def test_single_column_output():
                             .SelectMany(lambda e: e.Jets("AntiKt4EMTopoJets"))
                             .Select(lambda j: j.pt() ** 2))
     print(training_df)
-    assert int(training_df.iloc[0]['col1']) == 66211749007  # type: ignore
+    assert int(training_df.iloc[0]['col1']) == 2706562012  # type: ignore
     assert int(training_df.iloc[0]['col1']) != int(training_df.iloc[1]['col1'])  # type: ignore
 
 
@@ -92,8 +172,13 @@ def test_First_two_outer_loops():
     # on the number of tracks puts us another level down. So it is easy to produce code that compiles, but the First's if statement
     # is very much in the wrong place.
     training_df = as_pandas(f_single
-                            .Select('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: e.Tracks("InDetTrackParticles").Where(lambda t: t.pt() > 1000.0)).First().Count()'))
-    assert training_df.iloc[0]['col1'] == 693
+                            .Select(lambda e: e.Jets("AntiKt4EMTopoJets")
+                                    .Select(lambda j: e.Tracks("InDetTrackParticles")
+                                            .Where(lambda t: t.pt() > 1000.0))
+                                    .First()
+                                    .Count())
+                            )
+    assert training_df.iloc[0]['col1'] == 136
 
 
 def test_not_in_where():
@@ -101,15 +186,23 @@ def test_not_in_where():
     # on the number of tracks puts us another level down. So it is easy to produce code that compiles, but the First's if statement
     # is very much in the wrong place.
     training_df = as_pandas(f_single
-                            .Select('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: e.Tracks("InDetTrackParticles").Where(lambda t: not (t.pt() > 1000.0))).First().Count()'))
-    assert training_df.iloc[0]['col1'] == 1204
+                            .Select(lambda e: e.Jets("AntiKt4EMTopoJets")
+                                    .Select(lambda j: e.Tracks("InDetTrackParticles")
+                                    .Where(lambda t: not (t.pt() > 1000.0)))
+                                    .First()
+                                    .Count())
+                            )
+    assert training_df.iloc[0]['col1'] == 258
 
 
 def test_first_object_in_event():
     # Make sure First puts it if statement in the right place.
     training_df = as_pandas(f_single
-                            .Select('lambda e: e.Jets("AntiKt4EMTopoJets").First().pt()/1000.0'))
-    assert int(training_df.iloc[0]['col1']) == 257  # type: ignore
+                            .Select(lambda e: e.Jets("AntiKt4EMTopoJets")
+                                    .First()
+                                    .pt() / 1000.0)
+                            )
+    assert int(training_df.iloc[0]['col1']) == 52  # type: ignore
 
 
 def test_no_reported_statistics():
@@ -117,27 +210,34 @@ def test_no_reported_statistics():
 
     with LogCapture() as l_cap:
         as_pandas(f_single
-                  .Select('lambda e: e.Jets("AntiKt4EMTopoJets").First().pt()/1000.0'))
+                  .Select(lambda e: e.Jets("AntiKt4EMTopoJets")
+                          .First()
+                          .pt() / 1000.0)
+                  )
         assert str(l_cap).find('TFileAccessTracer   INFO    Sending') == -1
 
 
 def test_first_object_in_event_with_where():
     # Make sure First puts it's if statement in the right place.
     training_df = as_pandas(f_single
-                            .Select('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: j.pt()/1000.0).Where(lambda jpt: jpt > 10.0).First()'))
-    assert int(training_df.iloc[0]['col1']) == 257  # type: ignore
+                            .Select(lambda e: e.Jets("AntiKt4EMTopoJets")
+                                    .Select(lambda j: j.pt() / 1000.0)
+                                    .Where(lambda jpt: jpt > 10.0)
+                                    .First())
+                            )
+    assert int(training_df.iloc[0]['col1']) == 52  # type: ignore
     assert len(training_df) == 10
 
 
 def test_truth_particles():
     training_df = as_pandas(f_single
-                            .Select("lambda e: e.TruthParticles('TruthParticles').Count()"))
-    assert training_df.iloc[0]['col1'] == 1557
+                            .Select(lambda e: e.TruthParticles('TruthParticles').Count()))
+    assert training_df.iloc[0]['col1'] == 1450
 
 
 def test_truth_particles_awk():
     training_df = as_awkward(f_single
-                             .Select("lambda e: e.TruthParticles('TruthParticles').Count()"))
+                             .Select(lambda e: e.TruthParticles('TruthParticles').Count()))
     print(training_df)
     assert len(training_df[b'col1']) == 10
 
@@ -145,31 +245,41 @@ def test_truth_particles_awk():
 def test_1D_array():
     # A very simple flattening of arrays
     training_df = as_awkward(f_single
-                             .Select('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: j.pt()/1000.0)'))
+                             .Select(lambda e: e.Jets("AntiKt4EMTopoJets")
+                                     .Select(lambda j: j.pt() / 1000.0))
+                             )
     print(training_df)
     assert len(training_df[b'col1']) == 10
-    assert len(training_df[b'col1'][0]) == 32  # type: ignore
+    assert len(training_df[b'col1'][0]) == 9  # type: ignore
 
 
 def test_2D_array():
     # A very simple flattening of arrays
     training_df = as_awkward(f_single
-                             .Select('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: j.Jets("AntiKt4EMTopoJets").Select(lambda j1: j1.pt()/1000.0))'))
+                             .Select(lambda e: e.Jets("AntiKt4EMTopoJets")
+                                     .Select(lambda j: j.Jets("AntiKt4EMTopoJets")
+                                             .Select(lambda j1: j1.pt() / 1000.0))
+                                     )
+                             )
     print(training_df)
     assert len(training_df[b'col1']) == 10
-    assert len(training_df[b'col1'][0]) == 32  # type: ignore
-    assert len(training_df[b'col1'][0][0]) == 32  # type: ignore
+    assert len(training_df[b'col1'][0]) == 9  # type: ignore
+    assert len(training_df[b'col1'][0][0]) == 9  # type: ignore
 
 
 def test_2D_nested_where():
     # Seen in the wild as generating bad C++.
     training_df = as_awkward(f_single
-                             .Select('lambda e0304: (e0304.Jets("AntiKt4EMTopoJets"), e0304)')
-                             .Select('lambda e0305: (e0305[0].Where(lambda e0352: (((e0352.pt() / 1000.0) > 20)) and (((abs(e0352.eta())) < 1.5))), e0305[1])')
-                             .Select('lambda e0317: e0317[0].Select(lambda e0353: e0317[1].TruthParticles("TruthParticles").Where(lambda e0345: (e0345.pdgId() == 11)).Where(lambda e0346: (((e0346.pt() / 1000.0) > 20)) and (((abs(e0346.eta())) < 1.5))).Where(lambda e0347: (DeltaR(e0353.eta(), e0353.phi(), e0347.eta(), e0347.phi()) < 0.5)))')
-                             .Select('lambda e0348: e0348.Select(lambda e0354: e0354.Count())'))
+                             .Select(lambda e0304: (e0304.Jets("AntiKt4EMTopoJets"), e0304))
+                             .Select(lambda e0305: (e0305[0].Where(lambda e0352: (((e0352.pt() / 1000.0) > 20)) and (((abs(e0352.eta())) < 1.5))), e0305[1]))
+                             .Select(lambda e0317: e0317[0].Select(lambda e0353: e0317[1].TruthParticles("TruthParticles")
+                                                                   .Where(lambda e0345: (e0345.pdgId() == 11))
+                                                                   .Where(lambda e0346: (((e0346.pt() / 1000.0) > 20)) and (((abs(e0346.eta())) < 1.5)))
+                                                                   .Where(lambda e0347: (DeltaR(e0353.eta(), e0353.phi(), e0347.eta(), e0347.phi()) < 0.5)))
+                                     )
+                             .Select(lambda e0348: e0348.Select(lambda e0354: e0354.Count())))
 
     print(training_df)
     a = training_df[b'col1']
     assert len(a) == 10
-    assert len(a[0]) == 8  # type: ignore
+    assert len(a[0]) == 1  # type: ignore

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -655,6 +655,23 @@ def test_metadata_collection_bad_experiment():
     assert "backend; only" in str(e.value)
 
 
+def test_metadata_job_options():
+    'Integration test making sure we grab the job options'
+    r = (atlas_xaod_dataset()
+         .MetaData({
+                   'metadata_type': 'add_job_script',
+                   'name': 'Vertex',
+                   'script': [
+                       '# hi there',
+                   ]
+                   })
+         .Select(lambda e: e.EventInfo("EventInfo").runNumber())
+         .Select(lambda e: {'run_number': e})
+         .value())
+
+    assert len(r._job_option_blocks) == 1
+
+
 def test_event_collection_too_many_arg():
     'This is integration testing - making sure the dict to root conversion works'
     with pytest.raises(ValueError) as e:

--- a/tests/common/test_executor.py
+++ b/tests/common/test_executor.py
@@ -1,4 +1,5 @@
 import ast
+from func_adl_xAOD.atlas.xaod.query_ast_visitor import atlas_xaod_query_ast_visitor
 from typing import Callable, List
 from func_adl_xAOD.common.event_collections import EventCollectionSpecification, event_collection_coder, event_collection_container
 from func_adl_xAOD.common.cpp_ast import CPPCodeValue
@@ -18,7 +19,7 @@ class do_nothing_executor(executor):
         super().__init__([], 'stuff.sh', 'dude', {})
 
     def get_visitor_obj(self) -> query_ast_visitor:
-        assert False
+        return atlas_xaod_query_ast_visitor()
 
     def build_collection_callback(self, metadata: EventCollectionSpecification) -> Callable[[ast.Call], ast.Call]:
         ecc = dummy_event_collection_coder()

--- a/tests/utils/base.py
+++ b/tests/utils/base.py
@@ -150,6 +150,7 @@ class dummy_executor(ABC):
         a_transformed = rnr.apply_ast_transformations(a)
         self.ResultRep = \
             self.QueryVisitor.get_as_ROOT(a_transformed)
+        self._job_option_blocks = rnr._job_option_blocks
 
     def get_result(self, q_visitor, result_rep):
         'Got the result. Cache for use in tests'

--- a/tests/utils/base.py
+++ b/tests/utils/base.py
@@ -117,8 +117,11 @@ class LocalFile(EventDataset, ABC):
             if dump_cpp or proc.returncode != 0:
                 level = logging.INFO if proc.returncode == 0 else logging.ERROR
                 lg = logging.getLogger(__name__)
-                with open(os.path.join(str(local_run_dir), self._source_file_name), 'r') as f:
+                with (local_run_dir / self._source_file_name).open('r') as f:
                     lg.log(level, 'C++ Source Code:')
+                    _dump_split_string(f.read(), lambda l: lg.log(level, f'  {l}'))
+                with (local_run_dir / 'ATestRun_eljob.py').open('r') as f:
+                    lg.log(level, 'JobOptions Source:')
                     _dump_split_string(f.read(), lambda l: lg.log(level, f'  {l}'))
             if proc.returncode != 0:
                 raise Exception(f"Docker command failed with error {proc.returncode} ({docker_cmd})")

--- a/tests/utils/base.py
+++ b/tests/utils/base.py
@@ -1,4 +1,3 @@
-import os
 import ast
 import shutil
 import asyncio


### PR DESCRIPTION
Fixes #35

* Enable metadata that will inject configuration code into the analysis job's options
* Metadata blocks can depend on each other to enforce order of config
* Repeated metadata blocks are ignored
* Tested by running jet corrections
* Improve how the CI works (so we aren't running flake8 repeatedly)
