### PR TITLE
Enable Local Dataset Running

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9]
     runs-on: ${{ matrix.platform }}
     needs: flake8
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,7 @@ jobs:
       run: |
         flake8 --ignore=E501,W503  --exclude=func_adl_xAOD/template
 
-  test:
-
+  test-no-docker:
     strategy:
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
@@ -48,6 +47,31 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install git+https://github.com/iris-hep/ast-language.git@e6470deb68529e1885a4bc46f781e2fe43a6f4c8
         pip install --no-cache-dir -e .[test]
+        pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -m "not atlas_xaod_runner and not cms_aod_runner"
+
+
+  test-with-docker:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macOS-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9]
+    runs-on: ${{ matrix.platform }}
+    needs: flake8
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install git+https://github.com/iris-hep/ast-language.git@e6470deb68529e1885a4bc46f781e2fe43a6f4c8
+        pip install --no-cache-dir -e .[test,local]
         pip list
     - name: Test with pytest
       run: |

--- a/README.md
+++ b/README.md
@@ -92,3 +92,17 @@ In general, the `master` branch should pass all tests all the time. Releases are
 Publishing to PyPi:
 
 - Automated by declaring a new release (or pre-release) in github's web interface
+
+### Running Locally
+
+Designed for running locally, it is possible to setup and use the `xAOD` backend if you have `docker` installed on your local machine. To use this you first need to install the local flavor of this package:
+
+```bash
+pip install func_adl_xAOD[local]
+```
+
+You can then use the `xAODDataset` object or the `CMSRun1AODDataset` object to execute `qastle` running on a docker image for ATLAS or CMS Run 1 AOD, locally.
+
+- Specify the local path to files you want to run on in the arguments to the constructor
+- Files are run serially, and in a blocking way
+- This code is designed for development and testing work, and is not designed for large-scale production running on local files (not that that couldn't be done).

--- a/func_adl_xAOD/atlas/xaod/__init__.py
+++ b/func_adl_xAOD/atlas/xaod/__init__.py
@@ -1,1 +1,5 @@
-from .local_dataset import xAODDataset  # NOQA
+try:
+    import python_on_whales  # NOQA
+    from .local_dataset import xAODDataset  # NOQA
+except ImportError:
+    pass

--- a/func_adl_xAOD/atlas/xaod/__init__.py
+++ b/func_adl_xAOD/atlas/xaod/__init__.py
@@ -1,0 +1,1 @@
+from .local_dataset import xAODDataset  # NOQA

--- a/func_adl_xAOD/atlas/xaod/local_dataset.py
+++ b/func_adl_xAOD/atlas/xaod/local_dataset.py
@@ -1,5 +1,4 @@
 import ast
-import asyncio
 import logging
 import shutil
 import tempfile

--- a/func_adl_xAOD/atlas/xaod/local_dataset.py
+++ b/func_adl_xAOD/atlas/xaod/local_dataset.py
@@ -1,0 +1,147 @@
+import ast
+import asyncio
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from func_adl import EventDataset
+from func_adl_xAOD.atlas.xaod.executor import atlas_xaod_executor
+from func_adl_xAOD.common.executor import executor
+from func_adl_xAOD.common.result_ttree import cpp_ttree_rep
+from python_on_whales import docker
+
+
+class xAODDataset(EventDataset):
+    '''A dataset running locally
+    '''
+    def __init__(self, files: Path):
+        '''Run on the given files
+
+        Args:
+            files (Path): Locally accessible files we are going to run on
+        '''
+        super().__init__()
+        self.files = [files]
+        self._docker_image = 'atlas/analysisbase:21.2.191'
+        self._source_file_name = 'query.cxx'
+        # TODO: Protect against files not existing
+        # TODO: Make sure all files come from same directory
+        # TODO: Make sure there is at least one file
+        # TODO: Allow different atlas docker images/tags
+
+    def get_executor_obj(self) -> executor:
+        '''Return the code that will actually generate the C++ we need to execute
+        here.
+
+        Returns:
+            executor: Return the executor
+        '''
+        return atlas_xaod_executor()
+
+    async def execute_result_async(self, a: ast.AST, title: str) -> Any:
+        '''Take the `ast` and turn it into code and run it in docker, async.
+
+        Args:
+            a (ast.AST): The AST fo the query to run
+            title (str): Title of the query
+
+        Returns:
+            Any: List of files
+        '''
+        # Build everything in the local temp file directory.
+        with tempfile.TemporaryDirectory() as local_run_dir_p:
+
+            # Setup the local directory and make sure it is writeable
+            local_run_dir = Path(local_run_dir_p)
+            local_run_dir.chmod(0o777)
+
+            # Get the files that we can run
+            exe = self.get_executor_obj()
+            f_spec = exe.write_cpp_files(exe.apply_ast_transformations(a), local_run_dir)
+
+            # Write out a file with the mapped in directories.
+            # Until we better figure out how to deal with this, there are some restrictions
+            # on file locations.
+            datafile_dir: Optional[Path] = None
+            with open(f'{local_run_dir}/filelist.txt', 'w') as flist_out:
+                for u in self.files:
+
+                    ds_path = u.parent
+                    datafile = u.name
+                    flist_out.write(f'/data/{datafile}\n')
+                    if datafile_dir is None:
+                        datafile_dir = ds_path
+                    else:
+                        if ds_path != datafile_dir:
+                            raise Exception(f'Data files must be from the same directory. Have seen {ds_path} and {datafile_dir} so far.')
+
+            # Build the docker command and run it.
+            volumes_to_mount = [
+                (f_spec.output_path, '/scripts', 'ro'),
+                (f_spec.output_path, '/results', 'w'),
+                (datafile_dir, '/data/', 'ro'),
+            ]
+
+            output = docker.run(
+                self._docker_image, [f'/scripts/{f_spec.main_script}'],
+                volumes=volumes_to_mount,
+            )
+            # datafile_mount = f'-v {datafile_dir}:/data'
+            # docker_cmd = f'docker run --rm -v {f_spec.output_path}:/scripts -v {f_spec.output_path}:/results {datafile_mount} {self._docker_image} /scripts/{f_spec.main_script}'
+            # proc = await asyncio.create_subprocess_shell(docker_cmd,
+            #                                              stdout=asyncio.subprocess.PIPE,  # type: ignore
+            #                                              stderr=asyncio.subprocess.PIPE)  # type: ignore
+            # p_stdout, p_stderr = await proc.communicate()
+
+            # Inspect the results, dump out extra info, etc.
+            lg = logging.getLogger(__name__)
+
+            level = logging.DEBUG if proc.returncode != 0 else logging.ERROR
+            lg.log(level, f"Result of run: {proc.returncode}")
+            lg.log(level, 'std Output: ')
+            _dump_split_string(p_stdout.decode(), lambda l: lg.log(level, f'  {l}'))
+            lg.log(level, 'std Error: ')
+            _dump_split_string(p_stderr.decode(), lambda l: lg.log(level, f'  {l}'))
+
+            with (local_run_dir / self._source_file_name).open('r') as f:
+                lg.log(level, 'C++ Source Code:')
+                _dump_split_string(f.read(), lambda l: lg.log(level, f'  {l}'))
+            with (local_run_dir / 'ATestRun_eljob.py').open('r') as f:
+                lg.log(level, 'JobOptions Source:')
+                _dump_split_string(f.read(), lambda l: lg.log(level, f'  {l}'))
+            with (local_run_dir / 'package_CMakeLists.txt').open('r') as f:
+                lg.log(level, 'CMake Source:')
+                _dump_split_string(f.read(), lambda l: lg.log(level, f'  {l}'))
+
+            # And throw an error
+            if proc.returncode != 0:
+                raise RuntimeError(f"Failed to execute fun_adl query: ATLAS container failed with code {proc.returncode} ({docker_cmd})")
+
+            # Now that we have run, we can pluck out the result.
+            assert isinstance(f_spec.result_rep, cpp_ttree_rep), 'Unknown return type'
+            return _extract_result_TTree(f_spec.result_rep, local_run_dir)
+
+
+def _dump_split_string(s: str, dump: Callable[[str], None]):
+    for ll in s.split('\n'):
+        dump(ll)
+
+
+def _extract_result_TTree(rep: cpp_ttree_rep, run_dir):
+    '''Copy the final file into a place that is "safe", and return that as a path.
+
+    The reason for this is that the temp directory we are using is about to be deleted!
+
+    Args:
+        rep (cpp_base_rep): The representation of the final result
+        run_dir ([type]): Directory where it ran
+
+    Raises:
+        Exception: [description]
+    '''
+    current_path = run_dir / rep.filename
+    new_path = Path('.') / rep.filename
+    shutil.copy(current_path, new_path)
+    return new_path

--- a/func_adl_xAOD/atlas/xaod/local_dataset.py
+++ b/func_adl_xAOD/atlas/xaod/local_dataset.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 from func_adl_xAOD.common.local_dataset import LocalDataset
 from func_adl_xAOD.atlas.xaod.executor import atlas_xaod_executor
@@ -12,7 +12,8 @@ class xAODDataset(LocalDataset):
     def __init__(self,
                  files: Union[Path, str, List[Path], List[str]],
                  docker_image: str = 'atlas/analysisbase',
-                 docker_tag: str = '21.2.191'):
+                 docker_tag: str = '21.2.191',
+                 output_directory: Optional[Path] = None):
         '''Run on the given files
 
         Args:
@@ -20,7 +21,7 @@ class xAODDataset(LocalDataset):
             docker_image (str): The docker image name to run the executable
             docker_tag (str): The docker tag to use to run the executable
         '''
-        super().__init__(files, docker_image, docker_tag)
+        super().__init__(files, docker_image, docker_tag, output_directory)
 
     def get_executor_obj(self) -> executor:
         '''Return the code that will actually generate the C++ we need to execute

--- a/func_adl_xAOD/atlas/xaod/local_dataset.py
+++ b/func_adl_xAOD/atlas/xaod/local_dataset.py
@@ -10,7 +10,7 @@ class xAODDataset(LocalDataset):
     '''A dataset running locally
     '''
     def __init__(self,
-                 files: Union[Path, str, List[Path]],
+                 files: Union[Path, str, List[Path], List[str]],
                  docker_image: str = 'atlas/analysisbase',
                  docker_tag: str = '21.2.191'):
         '''Run on the given files

--- a/func_adl_xAOD/cms/aod/__init__.py
+++ b/func_adl_xAOD/cms/aod/__init__.py
@@ -1,2 +1,6 @@
 from .cms_functions import isNonnull  # NOQA
-from .local_dataset import CMSRun1AODDataset  # NOQA
+try:
+    import python_on_whales  # NOQA
+    from .local_dataset import CMSRun1AODDataset  # NOQA
+except ImportError:
+    pass

--- a/func_adl_xAOD/cms/aod/__init__.py
+++ b/func_adl_xAOD/cms/aod/__init__.py
@@ -1,1 +1,2 @@
 from .cms_functions import isNonnull  # NOQA
+from .local_dataset import CMSRun1AODDataset  # NOQA

--- a/func_adl_xAOD/cms/aod/cms_functions.py
+++ b/func_adl_xAOD/cms/aod/cms_functions.py
@@ -1,6 +1,8 @@
 import ast
 from typing import Callable, Dict
+
 import func_adl_xAOD.common.cpp_ast as cpp_ast
+import func_adl_xAOD.common.cpp_types as ctyp
 from func_adl_xAOD.common.cpp_representation import cpp_variable
 from func_adl_xAOD.common.cpp_vars import unique_name
 
@@ -25,7 +27,7 @@ def isNonnullAst(call_node):
     # The code is three steps
     r.running_code += ['auto result = (cms_object).isNonnull();']
     r.result = 'result'
-    r.result_rep = lambda scope: cpp_variable(unique_name('is_non_null'), scope=scope, cpp_type='bool')
+    r.result_rep = lambda scope: cpp_variable(unique_name('is_non_null'), scope=scope, cpp_type=ctyp.terminal('bool'))
 
     call_node.func = r
     return call_node

--- a/func_adl_xAOD/cms/aod/local_dataset.py
+++ b/func_adl_xAOD/cms/aod/local_dataset.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 from func_adl_xAOD.common.local_dataset import LocalDataset
 from func_adl_xAOD.cms.aod.executor import cms_aod_executor
@@ -12,7 +12,8 @@ class CMSRun1AODDataset(LocalDataset):
     def __init__(self,
                  files: Union[Path, str, List[Path], List[str]],
                  docker_image: str = 'cmsopendata/cmssw_5_3_32',
-                 docker_tag: str = 'conddb_20210705'):
+                 docker_tag: str = 'conddb_20210705',
+                 output_directory: Optional[Path] = None):
         '''Run on the given files
 
         Args:
@@ -20,7 +21,7 @@ class CMSRun1AODDataset(LocalDataset):
             docker_image (str): The docker image name to run the executable
             docker_tag (str): The docker tag to use to run the executable
         '''
-        super().__init__(files, docker_image, docker_tag)
+        super().__init__(files, docker_image, docker_tag, output_directory)
 
     def get_executor_obj(self) -> executor:
         '''Return the code that will actually generate the C++ we need to execute

--- a/func_adl_xAOD/cms/aod/local_dataset.py
+++ b/func_adl_xAOD/cms/aod/local_dataset.py
@@ -10,7 +10,7 @@ class CMSRun1AODDataset(LocalDataset):
     '''A dataset running locally
     '''
     def __init__(self,
-                 files: Union[Path, str, List[Path]],
+                 files: Union[Path, str, List[Path], List[str]],
                  docker_image: str = 'cmsopendata/cmssw_5_3_32',
                  docker_tag: str = 'conddb_20210705'):
         '''Run on the given files

--- a/func_adl_xAOD/cms/aod/local_dataset.py
+++ b/func_adl_xAOD/cms/aod/local_dataset.py
@@ -2,17 +2,17 @@ from pathlib import Path
 from typing import List, Union
 
 from func_adl_xAOD.common.local_dataset import LocalDataset
-from func_adl_xAOD.atlas.xaod.executor import atlas_xaod_executor
+from func_adl_xAOD.cms.aod.executor import cms_aod_executor
 from func_adl_xAOD.common.executor import executor
 
 
-class xAODDataset(LocalDataset):
+class CMSRun1AODDataset(LocalDataset):
     '''A dataset running locally
     '''
     def __init__(self,
                  files: Union[Path, str, List[Path]],
-                 docker_image: str = 'atlas/analysisbase',
-                 docker_tag: str = '21.2.191'):
+                 docker_image: str = 'cmsopendata/cmssw_5_3_32',
+                 docker_tag: str = 'conddb_20210705'):
         '''Run on the given files
 
         Args:
@@ -29,4 +29,4 @@ class xAODDataset(LocalDataset):
         Returns:
             executor: Return the executor
         '''
-        return atlas_xaod_executor()
+        return cms_aod_executor()

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -588,7 +588,9 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         arg_reps = [self.get_rep_value(a) for a in call_node.args]
 
         # Code up a call
-        r = crep.cpp_value('{0}({1})'.format(cpp_func.cpp_name, ','.join(a.as_cpp() for a in arg_reps)), self._gc.current_scope(), cpp_type=cpp_func.cpp_return_type)
+        r = crep.cpp_value(f'{cpp_func.cpp_name}({",".join(a.as_cpp() for a in arg_reps)})',
+                           self._gc.current_scope(),
+                           cpp_type=ctyp.terminal(cpp_func.cpp_return_type))
 
         # Include files and return the resulting expression
         for i in cpp_func.include_files:
@@ -781,7 +783,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         '''
 
         # The result of this test
-        result = crep.cpp_variable(unique_name('bool_op'), self._gc.current_scope(), cpp_type='bool')
+        result = crep.cpp_variable(unique_name('bool_op'), self._gc.current_scope(), cpp_type=ctyp.terminal('bool'))
         self._gc.declare_variable(result)
 
         # How we check and short-circuit depends on if we are doing and or or.

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -172,7 +172,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         if rep is None:
             FuncADLNodeVisitor.visit(self, node)
 
-    def get_rep(self, node: ast.AST, retain_scope: bool = False) -> Union[crep.cpp_rep_base]:
+    def get_rep(self, node: ast.AST, retain_scope: bool = False) -> crep.cpp_rep_base:
         r'''Return the rep for the node. If it isn't set yet, then run our visit on it.
 
         node - The ast node to generate a representation for.
@@ -967,14 +967,14 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
 
         assert len(args) == 2
         source = args[0]
-        selection = cast(ast.Lambda, args[1])
+        selection = args[1]
+        assert isinstance(selection, ast.Lambda)
 
         # Make sure we are in a loop
         seq = self.as_sequence(source)
 
         # Simulate this as a "call"
-        selection = lambda_unwrap(selection)
-        c = ast.Call(func=selection, args=[seq.sequence_value().as_ast()])
+        c = ast.Call(func=lambda_unwrap(selection), args=[seq.sequence_value().as_ast()])
         new_sequence_value = cast(crep.cpp_value, self.get_rep(c))
 
         # We need to build a new sequence.
@@ -996,12 +996,11 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         # Make sure the source is around. We have to do this because code generation in this
         # framework is lazy. And if the `selection` function does not use the source, and
         # looking at that source might generate a loop, that loop won't be generated! Ops!
-        _ = self.as_sequence(source)
+        seq = self.as_sequence(source)
 
         # We need to "call" the source with the function. So build up a new
         # call, and then visit it.
-
-        c = ast.Call(func=lambda_unwrap(selection), args=[source])
+        c = ast.Call(func=lambda_unwrap(selection), args=[seq.sequence_value().as_ast()])
 
         # Get the collection, and then generate the loop over it.
         # It could be that this comes back from something that is already iterating (like a Select statement),

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -113,7 +113,7 @@ def determine_type_mf(parent_type, function_name):
         raise xAODTranslationError(f'Unable to call method {function_name} on type {str(parent_type)}.')
 
     # Ok - we give up. Return a double.
-    logging.getLogger(__name__).warning(f"Warning: assumping that the method '{str(s_parent_type)}.{function_name}(...)' has return type 'double'. Use cpp_types.add_method_type_info to suppress (or correct) this warning.")
+    logging.getLogger(__name__).warning(f"Warning: assuming that the method '{str(s_parent_type)}.{function_name}(...)' has return type 'double'. Use cpp_types.add_method_type_info to suppress (or correct) this warning.")
     return ctyp.terminal('double')
 
 

--- a/func_adl_xAOD/common/cpp_ast.py
+++ b/func_adl_xAOD/common/cpp_ast.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, Optional, cast
 import func_adl_xAOD.common.statement as statements
 from func_adl_xAOD.common.cpp_representation import cpp_value, cpp_variable
 from func_adl_xAOD.common.cpp_vars import unique_name
+import func_adl_xAOD.common.cpp_types as ctyp
 from func_adl_xAOD.common.util_scope import gc_scope
 
 # The list of methods and the re-write functions for them. Each rewrite function
@@ -62,6 +63,7 @@ class CPPCodeValue (ast.AST):
 
 
 # Info used to build a code spec
+# TODO: Convert to a dataclass
 CPPCodeSpecification = namedtuple('CPPCodeSpecification', ['name', 'include_files', 'arguments', 'code', 'result', 'cpp_return_type'])
 
 
@@ -98,7 +100,7 @@ def build_CPPCodeValue(spec: CPPCodeSpecification, call_node: ast.Call) -> ast.C
     # The code is three steps
     r.running_code += spec.code
     r.result = spec.result
-    r.result_rep = lambda scope: cpp_variable(unique_name(spec.name), scope=scope, cpp_type=spec.cpp_return_type)
+    r.result_rep = lambda scope: cpp_variable(unique_name(spec.name), scope=scope, cpp_type=ctyp.terminal(spec.cpp_return_type))
 
     call_node.func = r  # type: ignore
     return call_node

--- a/func_adl_xAOD/common/cpp_functions.py
+++ b/func_adl_xAOD/common/cpp_functions.py
@@ -67,6 +67,7 @@ functions_to_replace = {}
 
 
 # The named tuple that stores the replacement info.
+# TODO: change to a typed data class
 cpp_function = namedtuple('cpp_function', ['cpp_name', 'include_files', 'cpp_return_type'])
 
 # CMATH functions - the catalog was pulled from

--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -184,7 +184,7 @@ class cpp_collection(cpp_value):
     Represents a special kind of value - a collection (vector<float>).
     '''
 
-    def __init__(self, cpp_expression: str, scope: gc_scope, collection_type: ctyp.collection):
+    def __init__(self, cpp_expression: str, scope: Union[gc_scope, gc_scope_top_level], collection_type: ctyp.collection):
         r'''
         Initialize a C++ value that can be turned into a sequence if requested.
 

--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -116,6 +116,7 @@ class cpp_value(cpp_rep_base):
         cpp_rep_base.__init__(self)
         self._scope = scope
         self._expression = cpp_expression
+        assert not isinstance(cpp_type, str)
         self._cpp_type = cpp_type
 
     def __str__(self) -> str:

--- a/func_adl_xAOD/common/cpp_types.py
+++ b/func_adl_xAOD/common/cpp_types.py
@@ -45,14 +45,19 @@ class terminal:
 class collection (terminal):
     'Represents a collection/list/vector of the same type'
 
-    def __init__(self, t, is_pointer=False):
+    def __init__(self, t, is_pointer: bool = False, array_type: Optional[str] = None):
         '''
         Initialize a collection type.
 
-        t:      The type of each element in the collection
+        t:          The type of each element in the collection
+        is_pointer: True if this is a pointer. Defaults to False.
+        array_type: The type of the array. Defaults to None, in which case
+                    vector<t> is used.
         '''
-        array_type = f"std::vector<{t}>"
-        terminal.__init__(self, array_type, is_pointer)
+        if array_type is None:
+            array_type = f"std::vector<{t}>"
+        super().__init__(array_type, is_pointer)
+
         self._element_type = t
 
     def element_type(self):

--- a/func_adl_xAOD/common/event_collections.py
+++ b/func_adl_xAOD/common/event_collections.py
@@ -52,6 +52,7 @@ class event_collection_collection(event_collection_container):
         self._is_element_pointer = is_element_pointer
 
     def element_type(self):
+        'Return a new terminal representing the element and type terminal'
         return ctyp.terminal(self._element_name, is_pointer=self._is_element_pointer)
 
     def dereference(self):

--- a/func_adl_xAOD/common/event_collections.py
+++ b/func_adl_xAOD/common/event_collections.py
@@ -13,6 +13,7 @@ from func_adl_xAOD.common.cpp_vars import unique_name
 
 # Need a type for our type system to reason about the containers.
 class event_collection_container(ABC):
+    # TODO: This should inherit from ctyp.collection!
     def __init__(self, type_name, is_pointer):
         self._type_name = type_name
         self._is_pointer = is_pointer
@@ -52,7 +53,6 @@ class event_collection_collection(event_collection_container):
         self._is_element_pointer = is_element_pointer
 
     def element_type(self):
-        'Return a new terminal representing the element and type terminal'
         return ctyp.terminal(self._element_name, is_pointer=self._is_element_pointer)
 
     def dereference(self):

--- a/func_adl_xAOD/common/local_dataset.py
+++ b/func_adl_xAOD/common/local_dataset.py
@@ -122,11 +122,17 @@ class LocalDataset(EventDataset, ABC):
 
             output: str = ""
             try:
-                output = docker.run(
+                output_generator = docker.run(
                     self._docker_image, [f'/scripts/{f_spec.main_script}'],
                     volumes=volumes_to_mount,
                     remove=True,
+                    stream=True,
                 )
+                for stream_type, stream_content in output_generator:
+                    if stream_type == 'stdout':
+                        output += f'{stream_content.decode()}'
+                    else:
+                        output += f'(stderr) {stream_content.decode()}'
                 self._dump_info(logging.DEBUG, output, local_run_dir, f_spec.main_script)
 
             except python_on_whales.exceptions.DockerException as e:

--- a/func_adl_xAOD/common/local_dataset.py
+++ b/func_adl_xAOD/common/local_dataset.py
@@ -18,7 +18,7 @@ class LocalDataset(EventDataset, ABC):
     '''A dataset running locally
     '''
     def __init__(self,
-                 files: Union[Path, str, List[Path]],
+                 files: Union[Path, str, List[Path], List[str]],
                  docker_image: str,
                  docker_tag: str):
         '''Run on the given files

--- a/func_adl_xAOD/common/local_dataset.py
+++ b/func_adl_xAOD/common/local_dataset.py
@@ -1,0 +1,157 @@
+from abc import ABC, abstractmethod
+import ast
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Union
+from collections.abc import Iterable
+
+from func_adl import EventDataset
+import python_on_whales
+from func_adl_xAOD.common.executor import executor
+from func_adl_xAOD.common.result_ttree import cpp_ttree_rep
+from python_on_whales import docker
+
+
+class LocalDataset(EventDataset, ABC):
+    '''A dataset running locally
+    '''
+    def __init__(self,
+                 files: Union[Path, str, List[Path]],
+                 docker_image: str,
+                 docker_tag: str):
+        '''Run on the given files
+
+        Args:
+            files (Path): Locally accessible files we are going to run on
+            docker_image (str): The docker image name to run the executable
+            docker_tag (str): The docker tag to use to run the executable
+        '''
+        super().__init__()
+
+        if isinstance(files, str):
+            f_list = [files]
+        else:
+            f_list = files if isinstance(files, Iterable) else [files]
+        self.files = [Path(f) if not isinstance(f, Path) else f for f in f_list]
+
+        if len(self.files) == 0:
+            raise RuntimeError('No files were given to the local dataset - need at least one good file')
+
+        self._docker_image = f'{docker_image}:{docker_tag}'
+
+        for f in self.files:
+            if not f.exists():
+                raise FileNotFoundError(f'File {f} does not exist')
+
+    @abstractmethod
+    def get_executor_obj(self) -> executor:
+        '''Return the code that will actually generate the C++ we need to execute
+        here.
+
+        Returns:
+            executor: Return the executor
+        '''
+
+    async def execute_result_async(self, a: ast.AST, title: str) -> Any:
+        '''Take the `ast` and turn it into code and run it in docker, async.
+
+        Args:
+            a (ast.AST): The AST fo the query to run
+            title (str): Title of the query
+
+        Returns:
+            Any: List of files
+        '''
+        # Build everything in the local temp file directory.
+        with tempfile.TemporaryDirectory() as local_run_dir_p:
+
+            # Setup the local directory and make sure it is writeable
+            local_run_dir = Path(local_run_dir_p)
+            local_run_dir.chmod(0o777)
+
+            # Get the files that we can run
+            exe = self.get_executor_obj()
+            f_spec = exe.write_cpp_files(exe.apply_ast_transformations(a), local_run_dir)
+
+            # Write out a file with the mapped in directories.
+            # Until we better figure out how to deal with this, there are some restrictions
+            # on file locations.
+            datafile_dir: Optional[Path] = None
+            with open(f'{local_run_dir}/filelist.txt', 'w') as flist_out:
+                for u in self.files:
+
+                    ds_path = u.parent
+                    datafile = u.name
+                    flist_out.write(f'/data/{datafile}\n')
+                    if datafile_dir is None:
+                        datafile_dir = ds_path
+                    else:
+                        if ds_path != datafile_dir:
+                            raise RuntimeError(f'Data files must be from the same directory. Have seen {ds_path} and {datafile_dir} so far.')
+
+            # Build the docker command and run it.
+            volumes_to_mount = [
+                (f_spec.output_path, '/scripts', 'ro'),
+                (f_spec.output_path, '/results', ''),
+                (datafile_dir, '/data/', 'ro'),
+            ]
+
+            output: str = ""
+            try:
+                output = docker.run(
+                    self._docker_image, [f'/scripts/{f_spec.main_script}'],
+                    volumes=volumes_to_mount,
+                    remove=True,
+                )
+                self._dump_info(logging.DEBUG, output, local_run_dir, f_spec.main_script)
+
+            except python_on_whales.exceptions.DockerException as e:
+                self._dump_info(logging.ERROR, output, local_run_dir, f_spec.main_script)
+                raise e
+
+            # Now that we have run, we can pluck out the result.
+            assert isinstance(f_spec.result_rep, cpp_ttree_rep), 'Unknown return type'
+            return [_extract_result_TTree(f_spec.result_rep, local_run_dir)]
+
+    def _dump_info(self, level, running_string: str, local_run_dir: Path, source_file_name: str):
+        '''Dump the logging info from a docker run.
+
+        Args:
+            level ([type]): The logging level
+            running_string (str): The string message from the run
+        '''
+        lg = logging.getLogger(__name__)
+
+        lg.log(level, 'Docker Output: ')
+        _dump_split_string(running_string, lambda l: lg.log(level, f'  {l}'))
+
+        for file in local_run_dir.glob('*'):
+            if file.is_file() and (file.suffix != '.root'):
+                lg.log(level, f'{file.name}:')
+                with file.open('r') as f:
+                    _dump_split_string(f.read(), lambda l: lg.log(level, f'  {l}'))
+
+
+def _dump_split_string(s: str, dump: Callable[[str], None]):
+    for ll in s.split('\n'):
+        dump(ll)
+
+
+def _extract_result_TTree(rep: cpp_ttree_rep, run_dir):
+    '''Copy the final file into a place that is "safe", and return that as a path.
+
+    The reason for this is that the temp directory we are using is about to be deleted!
+
+    Args:
+        rep (cpp_base_rep): The representation of the final result
+        run_dir ([type]): Directory where it ran
+
+    Raises:
+        Exception: [description]
+    '''
+    current_path = run_dir / rep.filename
+    new_path = Path('.') / rep.filename
+    shutil.copy(current_path, new_path)
+    return new_path

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -1,6 +1,6 @@
 from func_adl_xAOD.common.event_collections import EventCollectionSpecification
 from func_adl_xAOD.common.cpp_ast import CPPCodeSpecification
-from func_adl_xAOD.common.cpp_types import add_method_type_info, terminal
+from func_adl_xAOD.common.cpp_types import add_method_type_info, collection, terminal
 from typing import Any, Dict, List, Union
 from dataclasses import dataclass
 
@@ -28,7 +28,10 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecifi
             raise ValueError(f'Metadata is missing `metadata_type` info ({md})')
 
         if md_type == 'add_method_type_info':
-            add_method_type_info(md['type_string'], md['method_name'], terminal(md['return_type'], is_pointer=md['is_pointer'].upper() == 'TRUE'))
+            is_pointer = md['is_pointer'].upper() == 'TRUE'
+            term = terminal(md['return_type'], is_pointer=is_pointer) if 'return_type' in md \
+                else collection(md['return_type_element'], is_pointer=is_pointer, array_type=md['return_type_collection'] if 'return_type_collection' in md else None)
+            add_method_type_info(md['type_string'], md['method_name'], term)
         elif md_type == 'add_job_script':
             spec = JobScriptSpecification(
                 name=md['name'],

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -1,5 +1,3 @@
-from func_adl_xAOD.cms.aod.event_collections import cms_aod_event_collection_collection
-from func_adl_xAOD.atlas.xaod.event_collections import atlas_xaod_event_collection_collection, atlas_xaod_event_collection_container
 from func_adl_xAOD.common.event_collections import EventCollectionSpecification
 from func_adl_xAOD.common.cpp_ast import CPPCodeSpecification
 from func_adl_xAOD.common.cpp_types import add_method_type_info, terminal
@@ -55,6 +53,7 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecifi
             if (md['contains_collection'] and 'element_type' not in md) or (not md['contains_collection'] and 'element_type' in md):
                 raise ValueError('In collection metadata, `element_type` must be specified if `contains_collection` is true and not if it is false')
 
+            from func_adl_xAOD.atlas.xaod.event_collections import atlas_xaod_event_collection_collection, atlas_xaod_event_collection_container
             container_type = atlas_xaod_event_collection_collection(md['container_type'], md['element_type']) if md['contains_collection'] \
                 else atlas_xaod_event_collection_container(md['container_type'])
             link_libraries = [] if 'link_libraries' not in md else md['link_libraries']
@@ -72,6 +71,7 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecifi
             if (md['contains_collection'] and 'element_type' not in md) or (not md['contains_collection'] and 'element_type' in md):
                 raise ValueError('In collection metadata, `element_type` must be specified if `contains_collection` is true and not if it is false')
 
+            from func_adl_xAOD.cms.aod.event_collections import cms_aod_event_collection_collection
             container_type = cms_aod_event_collection_collection(md['container_type'], md['element_type'])
             # container_type = cms_aod_event_collection_collection(md['container_type'], md['element_type']) if md['contains_collection'] \
             #     else cms_aod_event_collection_container(md['container_type'])

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -30,7 +30,7 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecifi
         if md_type == 'add_method_type_info':
             is_pointer = md['is_pointer'].upper() == 'TRUE'
             term = terminal(md['return_type'], is_pointer=is_pointer) if 'return_type' in md \
-                else collection(md['return_type_element'], is_pointer=is_pointer, array_type=md['return_type_collection'] if 'return_type_collection' in md else None)
+                else collection(terminal(md['return_type_element']), is_pointer=is_pointer, array_type=md['return_type_collection'] if 'return_type_collection' in md else None)
             add_method_type_info(md['type_string'], md['method_name'], term)
         elif md_type == 'add_job_script':
             spec = JobScriptSpecification(

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -30,7 +30,7 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecifi
         if md_type == 'add_method_type_info':
             is_pointer = md['is_pointer'].upper() == 'TRUE'
             term = terminal(md['return_type'], is_pointer=is_pointer) if 'return_type' in md \
-                else collection(terminal(md['return_type_element']), is_pointer=is_pointer, array_type=md['return_type_collection'] if 'return_type_collection' in md else None)
+                else collection(terminal(md['return_type_element'], is_pointer=True), is_pointer=is_pointer, array_type=md['return_type_collection'] if 'return_type_collection' in md else None)
             add_method_type_info(md['type_string'], md['method_name'], term)
         elif md_type == 'add_job_script':
             spec = JobScriptSpecification(

--- a/func_adl_xAOD/template/cms/r5/runner.sh
+++ b/func_adl_xAOD/template/cms/r5/runner.sh
@@ -84,7 +84,7 @@ if [ $run = 1 ]; then
 
     # Figure out the output file
     if [ $output_method == "cp" ]; then
-        destination=$output_dir
+        destination=$output_dir/ANALYSIS.root
         cmd="cp"
     else
         destination=$1
@@ -102,10 +102,10 @@ if [ $run = 1 ]; then
     # CMS writes the tuples one directory down rather than in the top level.
     # Perhaps there is a more efficient way to solve this?
     if [ $cmd == "cp" ]; then
-        cvt='root -b -l -q /generated/copy_root_tree.C\(\"./$CMS_OUTPUT_FILE\",\"$destination\"\)'
+        cvt='root -b -l -q $DIR/copy_root_tree.C\(\"./$CMS_OUTPUT_FILE\",\"$destination\"\)'
         eval $cvt
     else
-        cvt='root -b -l -q /generated/copy_root_tree.C\(\"./$CMS_OUTPUT_FILE\",\"temp-output.root\"\)'
+        cvt='root -b -l -q $DIR/copy_root_tree.C\(\"./$CMS_OUTPUT_FILE\",\"temp-output.root\"\)'
         eval $cvt
         $cmd ./temp-output.root $destination
     fi

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ setup(name="func_adl_xAOD",
               "uproot",
               "awkward"
           ],
+          'local': [
+              'python-on-whales'
+          ]
       },
       classifiers=[
           "Development Status :: 3 - Alpha",

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -135,7 +135,7 @@ def run_docker(info: ExecutorInfo, code_dir: str, files: List[str],
                compile_only: bool = False, run_only: bool = False,
                add_position_argument_at_start: Optional[str] = None,
                extra_flag: Optional[str] = None,
-               output_dir: Optional[str] = None, mount_output: bool = True) -> Union[TemporaryDirectory]:
+               output_dir: Optional[str] = None, mount_output: bool = True) -> TemporaryDirectory:
     'Run the docker command'
 
     # Unravel the file path. How we do this depends on how we are doing this work.

--- a/tests/atlas/xaod/test_local_dataset.py
+++ b/tests/atlas/xaod/test_local_dataset.py
@@ -35,7 +35,7 @@ def docker_mock(mocker):
         return 'this is a\ntest'
 
     m.run.side_effect = parse_arg
-    mocker.patch('func_adl_xAOD.atlas.xaod.local_dataset.docker', m)
+    mocker.patch('func_adl_xAOD.common.local_dataset.docker', m)
     return m
 
 
@@ -50,7 +50,7 @@ def docker_mock_fail(mocker):
         raise DockerException(['docker command failed'], 125)
 
     m.run.side_effect = parse_arg
-    mocker.patch('func_adl_xAOD.atlas.xaod.local_dataset.docker', m)
+    mocker.patch('func_adl_xAOD.common.local_dataset.docker', m)
     return m
 
 
@@ -123,7 +123,7 @@ def test_no_file(docker_mock):
 
 def test_docker_error(docker_mock_fail):
     '''Test a simple run using docker mock'''
-    with pytest.raises(DockerException) as e:
+    with pytest.raises(DockerException):
         (xAODDataset([f_location])
             .Select(lambda e: e.EventInfo("EventInfo").runNumber())
             .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])

--- a/tests/atlas/xaod/test_local_dataset.py
+++ b/tests/atlas/xaod/test_local_dataset.py
@@ -20,6 +20,7 @@ def test_integrated_run():
          .value())
 
     assert len(r) == 1
+    assert r[0].exists()
 
 
 @pytest.fixture()
@@ -148,3 +149,15 @@ def test_docker_error(docker_mock_fail):
             .Select(lambda e: e.EventInfo("EventInfo").runNumber())
             .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
             .value())
+
+
+def test_alternate_dir(docker_mock):
+    'Make sure we can send the file to our own directory'
+    with tempfile.TemporaryDirectory() as tmpdir:
+        from func_adl_xAOD.atlas.xaod import xAODDataset
+        r = (xAODDataset(f_location, output_directory=Path(tmpdir))
+             .Select(lambda e: e.EventInfo("EventInfo").runNumber())
+             .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
+             .value())
+
+        assert str(r[0]).startswith(str(tmpdir))

--- a/tests/atlas/xaod/test_local_dataset.py
+++ b/tests/atlas/xaod/test_local_dataset.py
@@ -1,15 +1,18 @@
-from pathlib import Path
 import tempfile
+from pathlib import Path
 
-from python_on_whales.exceptions import DockerException
-from func_adl_xAOD.atlas.xaod import xAODDataset
-from .config import f_location
 import pytest
+
+from .config import f_location
+
+python_on_whales = pytest.importorskip("python_on_whales")
 
 
 @pytest.mark.atlas_xaod_runner
 def test_integrated_run():
     '''Test a simple run with docker'''
+    from func_adl_xAOD.atlas.xaod import xAODDataset
+
     # TODO: Using the type stuff, make sure replacing Select below with SelectMany makes a good error message
     r = (xAODDataset(f_location)
          .Select(lambda e: e.EventInfo("EventInfo").runNumber())
@@ -22,7 +25,6 @@ def test_integrated_run():
 @pytest.fixture()
 def docker_mock(mocker):
     'Mock the docker object'
-    import python_on_whales
     m = mocker.MagicMock(spec=python_on_whales.docker)
 
     def parse_arg(*args, **kwargs):
@@ -42,8 +44,8 @@ def docker_mock(mocker):
 @pytest.fixture()
 def docker_mock_fail(mocker):
     'Mock the docker object'
-    import python_on_whales
     m = mocker.MagicMock(spec=python_on_whales.docker)
+    from func_adl_xAOD.atlas.xaod import xAODDataset
 
     def parse_arg(*args, **kwargs):
         from python_on_whales.exceptions import DockerException
@@ -57,6 +59,7 @@ def docker_mock_fail(mocker):
 def test_run(docker_mock):
     '''Test a simple run using docker mock'''
     # TODO: Using the type stuff, make sure replacing Select below with SelectMany makes a good error message
+    from func_adl_xAOD.atlas.xaod import xAODDataset
     r = (xAODDataset(f_location)
          .Select(lambda e: e.EventInfo("EventInfo").runNumber())
          .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
@@ -67,6 +70,7 @@ def test_run(docker_mock):
 
 def test_string_file(docker_mock):
     '''Test a simple run using docker mock'''
+    from func_adl_xAOD.atlas.xaod import xAODDataset
     r = (xAODDataset(str(f_location))
          .Select(lambda e: e.EventInfo("EventInfo").runNumber())
          .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
@@ -77,6 +81,7 @@ def test_string_file(docker_mock):
 
 def test_multiple_files(docker_mock):
     '''Test a simple run using docker mock'''
+    from func_adl_xAOD.atlas.xaod import xAODDataset
     r = (xAODDataset([f_location, f_location])
          .Select(lambda e: e.EventInfo("EventInfo").runNumber())
          .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
@@ -87,6 +92,7 @@ def test_multiple_files(docker_mock):
 
 def test_different_directories(docker_mock):
     '''Test a simple run using docker mock'''
+    from func_adl_xAOD.atlas.xaod import xAODDataset
     with tempfile.TemporaryDirectory() as d:
         import shutil
         shutil.copy(f_location, d)
@@ -103,6 +109,7 @@ def test_different_directories(docker_mock):
 
 def test_bad_file(docker_mock):
     '''Test a simple run using docker mock'''
+    from func_adl_xAOD.atlas.xaod import xAODDataset
     with pytest.raises(FileNotFoundError):
         (xAODDataset(Path('/bad/path'))
             .Select(lambda e: e.EventInfo("EventInfo").runNumber())
@@ -112,6 +119,7 @@ def test_bad_file(docker_mock):
 
 def test_no_file(docker_mock):
     '''Test a simple run using docker mock'''
+    from func_adl_xAOD.atlas.xaod import xAODDataset
     with pytest.raises(RuntimeError) as e:
         (xAODDataset([])
             .Select(lambda e: e.EventInfo("EventInfo").runNumber())
@@ -123,6 +131,8 @@ def test_no_file(docker_mock):
 
 def test_docker_error(docker_mock_fail):
     '''Test a simple run using docker mock'''
+    from func_adl_xAOD.atlas.xaod import xAODDataset
+    from python_on_whales.exceptions import DockerException
     with pytest.raises(DockerException):
         (xAODDataset([f_location])
             .Select(lambda e: e.EventInfo("EventInfo").runNumber())

--- a/tests/atlas/xaod/test_local_dataset.py
+++ b/tests/atlas/xaod/test_local_dataset.py
@@ -1,0 +1,24 @@
+from func_adl_xAOD.atlas.xaod import xAODDataset
+from .config import f_location
+
+
+def test_integrated_run():
+    '''Test a simple run with docker'''
+    # TODO: Using the type stuff, make sure replacing Select below with SelectMany makes a good error message
+    r = (xAODDataset(f_location)
+         .Select(lambda e: e.EventInfo("EventInfo").runNumber())
+         .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
+         .value())
+
+    assert len(r) == 10
+
+
+def test_run():
+    '''Test a simple run using docker mock'''
+    # TODO: Using the type stuff, make sure replacing Select below with SelectMany makes a good error message
+    r = (xAODDataset(f_location)
+         .Select(lambda e: e.EventInfo("EventInfo").runNumber())
+         .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
+         .value())
+
+    assert len(r) == 10

--- a/tests/atlas/xaod/test_local_dataset.py
+++ b/tests/atlas/xaod/test_local_dataset.py
@@ -35,7 +35,7 @@ def docker_mock(mocker):
         data = data_s[0][0]
         (data / 'ANALYSIS.root').touch()
 
-        return 'this is a\ntest'
+        return (('stdout', b'this is a\ntest'),)
 
     m.run.side_effect = parse_arg
     mocker.patch('func_adl_xAOD.common.local_dataset.docker', m)

--- a/tests/atlas/xaod/test_local_dataset.py
+++ b/tests/atlas/xaod/test_local_dataset.py
@@ -45,7 +45,6 @@ def docker_mock(mocker):
 def docker_mock_fail(mocker):
     'Mock the docker object'
     m = mocker.MagicMock(spec=python_on_whales.docker)
-    from func_adl_xAOD.atlas.xaod import xAODDataset
 
     def parse_arg(*args, **kwargs):
         from python_on_whales.exceptions import DockerException

--- a/tests/atlas/xaod/test_local_dataset.py
+++ b/tests/atlas/xaod/test_local_dataset.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 import tempfile
+
+from python_on_whales.exceptions import DockerException
 from func_adl_xAOD.atlas.xaod import xAODDataset
 from .config import f_location
 import pytest
 
 
+@pytest.mark.atlas_xaod_runner
 def test_integrated_run():
     '''Test a simple run with docker'''
     # TODO: Using the type stuff, make sure replacing Select below with SelectMany makes a good error message
@@ -30,6 +33,21 @@ def docker_mock(mocker):
         (data / 'ANALYSIS.root').touch()
 
         return 'this is a\ntest'
+
+    m.run.side_effect = parse_arg
+    mocker.patch('func_adl_xAOD.atlas.xaod.local_dataset.docker', m)
+    return m
+
+
+@pytest.fixture()
+def docker_mock_fail(mocker):
+    'Mock the docker object'
+    import python_on_whales
+    m = mocker.MagicMock(spec=python_on_whales.docker)
+
+    def parse_arg(*args, **kwargs):
+        from python_on_whales.exceptions import DockerException
+        raise DockerException(['docker command failed'], 125)
 
     m.run.side_effect = parse_arg
     mocker.patch('func_adl_xAOD.atlas.xaod.local_dataset.docker', m)
@@ -101,3 +119,12 @@ def test_no_file(docker_mock):
             .value())
 
     assert 'No files' in str(e)
+
+
+def test_docker_error(docker_mock_fail):
+    '''Test a simple run using docker mock'''
+    with pytest.raises(DockerException) as e:
+        (xAODDataset([f_location])
+            .Select(lambda e: e.EventInfo("EventInfo").runNumber())
+            .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
+            .value())

--- a/tests/atlas/xaod/test_local_dataset.py
+++ b/tests/atlas/xaod/test_local_dataset.py
@@ -1,5 +1,6 @@
 from func_adl_xAOD.atlas.xaod import xAODDataset
 from .config import f_location
+import pytest
 
 
 def test_integrated_run():
@@ -10,10 +11,30 @@ def test_integrated_run():
          .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
          .value())
 
-    assert len(r) == 10
+    assert len(r) == 1
 
 
-def test_run():
+@pytest.fixture()
+def docker_mock(mocker):
+    'Mock the docker object'
+    import python_on_whales
+    m = mocker.MagicMock(spec=python_on_whales.docker)
+
+    def parse_arg(*args, **kwargs):
+        v = kwargs['volumes']
+        data_s = [d for d in v if d[1] == '/results']
+        assert len(data_s) == 1
+        data = data_s[0][0]
+        (data / 'ANALYSIS.root').touch()
+
+        return 'this is a\ntest'
+
+    m.run.side_effect = parse_arg
+    mocker.patch('func_adl_xAOD.atlas.xaod.local_dataset.docker', m)
+    return m
+
+
+def test_run(docker_mock):
     '''Test a simple run using docker mock'''
     # TODO: Using the type stuff, make sure replacing Select below with SelectMany makes a good error message
     r = (xAODDataset(f_location)
@@ -21,4 +42,4 @@ def test_run():
          .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
          .value())
 
-    assert len(r) == 10
+    assert len(r) == 1

--- a/tests/atlas/xaod/test_local_dataset.py
+++ b/tests/atlas/xaod/test_local_dataset.py
@@ -89,6 +89,17 @@ def test_multiple_files(docker_mock):
     assert len(r) == 1
 
 
+def test_multiple_files_str(docker_mock):
+    '''Test a simple run using docker mock'''
+    from func_adl_xAOD.atlas.xaod import xAODDataset
+    r = (xAODDataset([str(f_location), str(f_location)])
+         .Select(lambda e: e.EventInfo("EventInfo").runNumber())
+         .AsROOTTTree('junk.root', 'my_tree', ['eventNumber'])
+         .value())
+
+    assert len(r) == 1
+
+
 def test_different_directories(docker_mock):
     '''Test a simple run using docker mock'''
     from func_adl_xAOD.atlas.xaod import xAODDataset

--- a/tests/atlas/xaod/test_query_ast_visitor.py
+++ b/tests/atlas/xaod/test_query_ast_visitor.py
@@ -133,12 +133,12 @@ def test_as_root_as_tuple():
 def test_subscript():
     q = atlas_xaod_query_ast_visitor()
     our_a = ast.Name(id='a')
-    our_a.rep = crep.cpp_collection('jets', gc_scope_top_level(), ctyp.collection('int'))  # type: ignore
+    our_a.rep = crep.cpp_collection('jets', gc_scope_top_level(), ctyp.collection(ctyp.terminal('int')))  # type: ignore
     node = ast_parse_with_replacement('a[10]', {'a': our_a}).body[0].value  # type: ignore
     as_root = q.get_rep(node)
 
     assert isinstance(as_root, crep.cpp_value)
-    assert as_root.cpp_type() == 'int'
+    assert str(as_root.cpp_type()) == 'int'
     assert as_root.as_cpp() == 'jets.at(10)'
 
 

--- a/tests/atlas/xaod/test_simple_type_info.py
+++ b/tests/atlas/xaod/test_simple_type_info.py
@@ -22,3 +22,13 @@ def test_can_call_prodVtx():
     atlas_xaod_dataset("file://root.root") \
         .Select("lambda e: e.TruthParticles('TruthParticles').Select(lambda t: t.prodVtx().x()).Sum()") \
         .value()
+
+
+def test_collection_return():
+    'Make sure we can set and deal with a returned collection properly'
+    ctyp.add_method_type_info("xAOD::TruthParticle", "vertexes", ctyp.collection('double', is_pointer=False))
+    (atlas_xaod_dataset("file://root.root")
+     .SelectMany(lambda e: e.TruthParticles('TruthParticles'))
+     .SelectMany(lambda t: t.vertexes())
+     .value()
+     )

--- a/tests/atlas/xaod/test_simple_type_info.py
+++ b/tests/atlas/xaod/test_simple_type_info.py
@@ -26,7 +26,7 @@ def test_can_call_prodVtx():
 
 def test_collection_return():
     'Make sure we can set and deal with a returned collection properly'
-    ctyp.add_method_type_info("xAOD::TruthParticle", "vertexes", ctyp.collection('double', is_pointer=False))
+    ctyp.add_method_type_info("xAOD::TruthParticle", "vertexes", ctyp.collection(ctyp.terminal('double'), is_pointer=False))
     (atlas_xaod_dataset("file://root.root")
      .SelectMany(lambda e: e.TruthParticles('TruthParticles'))
      .SelectMany(lambda t: t.vertexes())

--- a/tests/cms/aod/test_local_dataset.py
+++ b/tests/cms/aod/test_local_dataset.py
@@ -30,7 +30,7 @@ def docker_mock(mocker):
         data = data_s[0][0]
         (data / 'ANALYSIS.root').touch()
 
-        return 'this is a\ntest'
+        return (('stdout', b'text'), ('stderr', b'text'))
 
     m.run.side_effect = parse_arg
     mocker.patch('func_adl_xAOD.common.local_dataset.docker', m)

--- a/tests/cms/aod/test_local_dataset.py
+++ b/tests/cms/aod/test_local_dataset.py
@@ -1,0 +1,47 @@
+from func_adl_xAOD.cms.aod.local_dataset import CMSRun1AODDataset
+from .config import f_location
+import pytest
+
+
+@pytest.mark.cms_aod_runner
+def test_integrated_run():
+    '''Test a simple run with docker'''
+    # TODO: Using the type stuff, make sure replacing Select below with SelectMany makes a good error message
+    r = (CMSRun1AODDataset(f_location)
+         .SelectMany('lambda e: e.TrackMuons("globalMuons")')
+         .Select('lambda m: m.pt()')
+         .AsROOTTTree('junk.root', 'my_tree', ['muon_pt'])
+         .value())
+
+    assert len(r) == 1
+
+
+@pytest.fixture()
+def docker_mock(mocker):
+    'Mock the docker object'
+    import python_on_whales
+    m = mocker.MagicMock(spec=python_on_whales.docker)
+
+    def parse_arg(*args, **kwargs):
+        v = kwargs['volumes']
+        data_s = [d for d in v if d[1] == '/results']
+        assert len(data_s) == 1
+        data = data_s[0][0]
+        (data / 'ANALYSIS.root').touch()
+
+        return 'this is a\ntest'
+
+    m.run.side_effect = parse_arg
+    mocker.patch('func_adl_xAOD.common.local_dataset.docker', m)
+    return m
+
+
+def test_run(docker_mock):
+    '''Test a simple run using docker mock'''
+    r = (CMSRun1AODDataset(f_location)
+         .SelectMany('lambda e: e.TrackMuons("globalMuons")')
+         .Select('lambda m: m.pt()')
+         .AsROOTTTree('junk.root', 'my_tree', ['muon_pt'])
+         .value())
+
+    assert len(r) == 1

--- a/tests/cms/aod/test_local_dataset.py
+++ b/tests/cms/aod/test_local_dataset.py
@@ -1,12 +1,14 @@
-from func_adl_xAOD.cms.aod.local_dataset import CMSRun1AODDataset
 from .config import f_location
 import pytest
+
+python_on_whales = pytest.importorskip("python_on_whales")
 
 
 @pytest.mark.cms_aod_runner
 def test_integrated_run():
     '''Test a simple run with docker'''
     # TODO: Using the type stuff, make sure replacing Select below with SelectMany makes a good error message
+    from func_adl_xAOD.cms.aod.local_dataset import CMSRun1AODDataset
     r = (CMSRun1AODDataset(f_location)
          .SelectMany('lambda e: e.TrackMuons("globalMuons")')
          .Select('lambda m: m.pt()')
@@ -19,7 +21,6 @@ def test_integrated_run():
 @pytest.fixture()
 def docker_mock(mocker):
     'Mock the docker object'
-    import python_on_whales
     m = mocker.MagicMock(spec=python_on_whales.docker)
 
     def parse_arg(*args, **kwargs):
@@ -38,6 +39,7 @@ def docker_mock(mocker):
 
 def test_run(docker_mock):
     '''Test a simple run using docker mock'''
+    from func_adl_xAOD.cms.aod.local_dataset import CMSRun1AODDataset
     r = (CMSRun1AODDataset(f_location)
          .SelectMany('lambda e: e.TrackMuons("globalMuons")')
          .Select('lambda m: m.pt()')

--- a/tests/cms/aod/utils.py
+++ b/tests/cms/aod/utils.py
@@ -80,7 +80,7 @@ def load_root_as_pandas(file: Path) -> pd.DataFrame:
     assert file.exists()
 
     with uproot.open(file) as input:
-        return input['demo/cms_aod_tree'].arrays(library='pd')  # type: ignore
+        return input['cms_aod_tree'].arrays(library='pd')  # type: ignore
 
 
 def load_root_as_awkward(file: Path) -> ak.Array:

--- a/tests/common/test_cpp_types.py
+++ b/tests/common/test_cpp_types.py
@@ -25,3 +25,8 @@ def test_terminal_type():
 def test_collection():
     c = ctyp.collection('double', False)
     assert c.type == 'std::vector<double>'
+
+
+def test_collection_with_arr_type():
+    c = ctyp.collection('double', False, 'VectorOfFloats')
+    assert c.type == 'VectorOfFloats'

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -7,7 +7,7 @@ import func_adl_xAOD.common.statement as statement
 import pytest
 from func_adl_xAOD.common.ast_to_cpp_translator import query_ast_visitor
 from func_adl_xAOD.common.cpp_ast import CPPCodeSpecification
-from func_adl_xAOD.common.cpp_types import collection, method_type_info
+from func_adl_xAOD.common.cpp_types import collection, method_type_info, terminal
 from func_adl_xAOD.common.event_collections import (
     EventCollectionSpecification, event_collection_coder, event_collection_container)
 from func_adl_xAOD.common.executor import executor
@@ -84,7 +84,8 @@ def test_md_method_type_collection():
     assert t is not None
     assert isinstance(t, collection)
     assert t.type == 'std::vector<double>'
-    assert t.element_type() == 'double'
+    assert isinstance(t.element_type(), terminal)
+    assert str(t.element_type()) == 'double'
     assert t.is_pointer() is False
 
 
@@ -107,7 +108,7 @@ def test_md_method_type_custom_collection():
     assert t is not None
     assert isinstance(t, collection)
     assert t.type == 'MyCustomCollection'
-    assert t.element_type() == 'double'
+    assert str(t.element_type()) == 'double'
     assert t.is_pointer() is False
 
 

--- a/tests/utils/base.py
+++ b/tests/utils/base.py
@@ -116,15 +116,11 @@ class LocalFile(EventDataset, ABC):
             if dump_cpp or proc.returncode != 0:
                 level = logging.INFO if proc.returncode == 0 else logging.ERROR
                 lg = logging.getLogger(__name__)
-                with (local_run_dir / self._source_file_name).open('r') as f:
-                    lg.log(level, 'C++ Source Code:')
-                    _dump_split_string(f.read(), lambda l: lg.log(level, f'  {l}'))
-                with (local_run_dir / 'ATestRun_eljob.py').open('r') as f:
-                    lg.log(level, 'JobOptions Source:')
-                    _dump_split_string(f.read(), lambda l: lg.log(level, f'  {l}'))
-                with (local_run_dir / 'package_CMakeLists.txt').open('r') as f:
-                    lg.log(level, 'CMake Source:')
-                    _dump_split_string(f.read(), lambda l: lg.log(level, f'  {l}'))
+                for file in local_run_dir.glob('*'):
+                    if file.is_file() and (file.suffix != '.root'):
+                        lg.log(level, f'{file.name}:')
+                        with file.open('r') as f:
+                            _dump_split_string(f.read(), lambda l: lg.log(level, f'  {l}'))
             if proc.returncode != 0:
                 raise Exception(f"Docker command failed with error {proc.returncode} ({docker_cmd})")
 


### PR DESCRIPTION
* Added `CMSRun1AODDataset` and `xAODDataset` that can use a list of files on the local machine and produce root files as output (fixes #55).
* Adds a `local` option that lets you import the local dataset (so you don't normally). If you want to use the above, you must add the `local` option.
* Docker is required on the machine where this runs. It works on Windows, MacOS, and Linux. The image pull, however, is substantial (5 GB images for the CMS and ATLAS environments).
* Update the CI to make sure the non-`local` version installs properly.
* CMS `runner.sh` updated to use the latest CMS image
* Upon an error from the containers, a full dump of the files is made to help with debugging. This will generate quite a bit of output, however!

## Left to do:

- [ ] Update the documentation to reflect this change