### PR TITLE
MetaData Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ For a single item:
 
 For a collection:
 
-
 ### Output Formats
 
 The `xAOD` code only renders the `func_adl` expression as a ROOT file. The ROOT file contains a simple `TTree` in its root directory.

--- a/README.md
+++ b/README.md
@@ -142,3 +142,11 @@ You can then use the `xAODDataset` object or the `CMSRun1AODDataset` object to e
 - Specify the local path to files you want to run on in the arguments to the constructor
 - Files are run serially, and in a blocking way
 - This code is designed for development and testing work, and is not designed for large-scale production running on local files (not that that couldn't be done).
+
+When something odd happens and you really want to look at the C++ output, you can do this by including the following code somewhere before the `xAOD` backend is executed. This will turn on logging that will dump the output from the run and will also dump the C++ header and source files that were used to execute the query.
+
+```python
+import logging
+logging.basicConfig()
+logging.getLogger("func_adl_xAOD.common.local_dataset").setLevel(level=logging.DEBUG)
+```

--- a/README.md
+++ b/README.md
@@ -86,6 +86,33 @@ For a _collection_:
 | return_type_element | The type of the collection element | `"float"` |
 | return_type_collection | The type of the collection | `vector<float>`, `vector<float>*` |
 
+#### Event Level Collections
+
+CMS and ATLAS store their basic reconstruction objects as collections (e.g. jets, etc.). You can define new collections on the fly with the following metadata
+
+For _atlas_:
+
+| Key | Description | Example |
+| ------------ | ------------ | --------------|
+| metadata_type | The metadata type | `"add_atlas_event_collection_info"` |
+| name | The name of the collection (used to access it from the dataset object) | `"TruthParticles"` |
+| include_files| List of include files to use when accessing collection | `['file1.h', 'file2.h']` |
+| container_type | The container object that is filled | "'xAOD::ElectronContainer'" |
+| element_type | The element in the container. In atlas this is a pointer. | `"xAOD::Electron"` |
+| contains_collection | Some items are singletons (like `EventInfo`) | `True` or `False` |
+
+For _cms_:
+
+| Key | Description | Example |
+| ------------ | ------------ | --------------|
+| metadata_type | The metadata type | `"add_cms_event_collection_info"` |
+| name | The name of the collection (used to access it from the dataset object) | `"Vertex"` |
+| include_files| List of include files to use when accessing collection | `['DataFormats/VertexReco/interface/Vertex.h']` |
+| container_type | The container object that is filled | "'reco::VertexCollection'" |
+| element_type | The element in the container. In atlas this is a pointer. | `"reco::Vertex"` |
+| contains_collection | Some items are singletons (like `EventInfo`) | `True` or `False` |
+| element_pointer | Indicates if the element type is a pointer | `True` or `False` |
+
 #### Include Files
 
 Any include files listed will be added to the top of the `query.cpp` file that is generated. While ordering is maintained within a single `Metadata` query here, it is not maintained between different `Metadata` calls.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ For a _single item_:
 | type_string | The object the method applies to, fully qualified, C++ | `"xAOD::Jet"` |
 | method_name | Name of the method | `"pT"` |
 | return_type | Type returned, C++, fully qualified | `"float"`, `"float*"`, `"float**"` |
+| deref_count | Number of times to dereference object before invoking this method (optional) | 2 |
+
+Note: `deref_count` is used when an object can "hide" hold onto other objects by dereferencing them (e.g. by overriding the operator `operator*`). If it is zero (as it mostly is since `operator*` isn't often overridden), then it can be omitted.
 
 For a _collection_:
 
@@ -85,6 +88,7 @@ For a _collection_:
 | method_name | Name of the method | `"jetWeights"` |
 | return_type_element | The type of the collection element | `"float"` |
 | return_type_collection | The type of the collection | `vector<float>`, `vector<float>*` |
+| deref_count | Number of times to dereference object before invoking this method (optional) | 2 |
 
 #### Event Level Collections
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ Template functions don't make sense yet in python.
 - Do not use `math.sin` in a call. However `sin` is just fine. If you do, you'll get an exception during resolution that it doesn't know how to translate `math`.
 - for things like `sum`, `min`, `max`, etc., use the `Sum`, `Min`, `Max` LINQ predicates.
 
+### Metadata
+
+It is possible to inject metadata into the `qastle` query to alter the behavior of the C++ code production. Each sub-section below has a different type of metadata. In order to invoke this, use the `Metadata` call, which takes as input stream and outputs the same stream, but the argument is a dictionary which contains the metadata.
+
+#### Method Return Type
+
+If you have a method that returns a non-standard type, use this metadata type to specify to the backend the return type. There are two different forms for this metadata - one if a single item is returned, and another if a collection of items are returned.
+
+For a single item:
+
+| Key | Description | Example |
+| ------------ | ------------ | --------------|
+| metadata_type | The metadata type | "add_method_type_info" |
+| type_string | The object the method applies to, fully qualified, C++ | "xAOD::Jet" |
+| method_name | Name of the method | "pT" |
+| return_type | Type returned, C++, fully qualified | "float" |
+| is_pointer | Is the return type a pointer or the object directly (`my_obj*` vs `my_obj`) | "True" or "False" |
+
+For a collection:
+
+
 ### Output Formats
 
 The `xAOD` code only renders the `func_adl` expression as a ROOT file. The ROOT file contains a simple `TTree` in its root directory.

--- a/README.md
+++ b/README.md
@@ -67,17 +67,24 @@ It is possible to inject metadata into the `qastle` query to alter the behavior 
 
 If you have a method that returns a non-standard type, use this metadata type to specify to the backend the return type. There are two different forms for this metadata - one if a single item is returned, and another if a collection of items are returned.
 
-For a single item:
+For a _single item_:
 
 | Key | Description | Example |
 | ------------ | ------------ | --------------|
 | metadata_type | The metadata type | `"add_method_type_info"` |
 | type_string | The object the method applies to, fully qualified, C++ | `"xAOD::Jet"` |
 | method_name | Name of the method | `"pT"` |
-| return_type | Type returned, C++, fully qualified | `"float"` |
-| is_pointer | Is the return type a pointer or the object directly (`my_obj*` vs `my_obj`) | `"True"` or `"False"` |
+| return_type | Type returned, C++, fully qualified | `"float"`, `"float*"`, `"float**"` |
 
-For a collection:
+For a _collection_:
+
+| Key | Description | Example |
+| ------------ | ------------ | --------------|
+| metadata_type | The metadata type | `"add_method_type_info"` |
+| type_string | The object the method applies to, fully qualified, C++ | `"xAOD::Jet"` |
+| method_name | Name of the method | `"jetWeights"` |
+| return_type_element | The type of the collection element | `"float"` |
+| return_type_collection | The type of the collection | `vector<float>`, `vector<float>*` |
 
 #### Include Files
 
@@ -151,4 +158,4 @@ logging.basicConfig()
 logging.getLogger("func_adl_xAOD.common.local_dataset").setLevel(level=logging.DEBUG)
 ```
 
-* In general, the first two lines are a good thing to have in your notebooks, etc. It allows you to see where warning messages are coming from and might help when things are going sideways.
+- In general, the first two lines are a good thing to have in your notebooks, etc. It allows you to see where warning messages are coming from and might help when things are going sideways.

--- a/README.md
+++ b/README.md
@@ -150,3 +150,5 @@ import logging
 logging.basicConfig()
 logging.getLogger("func_adl_xAOD.common.local_dataset").setLevel(level=logging.DEBUG)
 ```
+
+* In general, the first two lines are a good thing to have in your notebooks, etc. It allows you to see where warning messages are coming from and might help when things are going sideways.

--- a/README.md
+++ b/README.md
@@ -71,13 +71,29 @@ For a single item:
 
 | Key | Description | Example |
 | ------------ | ------------ | --------------|
-| metadata_type | The metadata type | "add_method_type_info" |
-| type_string | The object the method applies to, fully qualified, C++ | "xAOD::Jet" |
-| method_name | Name of the method | "pT" |
-| return_type | Type returned, C++, fully qualified | "float" |
-| is_pointer | Is the return type a pointer or the object directly (`my_obj*` vs `my_obj`) | "True" or "False" |
+| metadata_type | The metadata type | `"add_method_type_info"` |
+| type_string | The object the method applies to, fully qualified, C++ | `"xAOD::Jet"` |
+| method_name | Name of the method | `"pT"` |
+| return_type | Type returned, C++, fully qualified | `"float"` |
+| is_pointer | Is the return type a pointer or the object directly (`my_obj*` vs `my_obj`) | `"True"` or `"False"` |
 
 For a collection:
+
+#### Include Files
+
+Any include files listed will be added to the top of the `query.cpp` file that is generated. While ordering is maintained within a single `Metadata` query here, it is not maintained between different `Metadata` calls.
+
+All includes are done with straight quotes:
+
+```C++
+#include "file1.hpp"
+#include "file2.hpp"
+```
+
+| Key | Description | Example |
+| ------------ | ------------ | --------------|
+| metadata_type | The metadata type | `"include_files"` |
+| files | List of files to include. | `["file1.hpp", "file2.hpp"]` |
 
 ### Output Formats
 

--- a/func_adl_xAOD/atlas/xaod/event_collections.py
+++ b/func_adl_xAOD/atlas/xaod/event_collections.py
@@ -1,3 +1,4 @@
+from typing import Union
 import func_adl_xAOD.common.cpp_types as ctyp
 from func_adl_xAOD.common.event_collections import (
     EventCollectionSpecification, event_collection_coder,
@@ -5,16 +6,18 @@ from func_adl_xAOD.common.event_collections import (
 
 
 class atlas_xaod_event_collection_container(event_collection_container):
-    def __init__(self, type_name, is_pointer=True):
-        super().__init__(type_name, is_pointer)
+    def __init__(self, type_name: Union[str, ctyp.CPPParsedTypeInfo], p_depth: int = 1):
+        super().__init__(type_name, p_depth=p_depth)
 
     def __str__(self):
         return f"const {self.type} *"
 
 
 class atlas_xaod_event_collection_collection(event_collection_collection_container):
-    def __init__(self, type_name, element_name, is_type_pointer=True, is_element_pointer=True):
-        super().__init__(type_name, element_name, is_type_pointer, is_element_pointer)
+    def __init__(self, type_name: Union[str, ctyp.CPPParsedTypeInfo],
+                 element_name: Union[str, ctyp.CPPParsedTypeInfo],
+                 p_depth_type: int = 1, p_depth_element: int = 1):
+        super().__init__(type_name, element_name, p_depth_element=p_depth_element, p_depth_type=p_depth_type)
 
     def __str__(self):
         return f"const {self.type}*"

--- a/func_adl_xAOD/atlas/xaod/event_collections.py
+++ b/func_adl_xAOD/atlas/xaod/event_collections.py
@@ -63,10 +63,10 @@ atlas_xaod_collections = [
 
 def define_default_atlas_types():
     'Define the default atlas types'
-    ctyp.add_method_type_info("xAOD::TruthParticle", "prodVtx", ctyp.terminal('xAODTruth::TruthVertex', is_pointer=True))
-    ctyp.add_method_type_info("xAOD::TruthParticle", "decayVtx", ctyp.terminal('xAODTruth::TruthVertex', is_pointer=True))
-    ctyp.add_method_type_info("xAOD::TruthParticle", "parent", ctyp.terminal('xAOD::TruthParticle', is_pointer=True))
-    ctyp.add_method_type_info("xAOD::TruthParticle", "child", ctyp.terminal('xAOD::TruthParticle', is_pointer=True))
+    ctyp.add_method_type_info("xAOD::TruthParticle", "prodVtx", ctyp.terminal('xAODTruth::TruthVertex', p_depth=1))
+    ctyp.add_method_type_info("xAOD::TruthParticle", "decayVtx", ctyp.terminal('xAODTruth::TruthVertex', p_depth=1))
+    ctyp.add_method_type_info("xAOD::TruthParticle", "parent", ctyp.terminal('xAOD::TruthParticle', p_depth=1))
+    ctyp.add_method_type_info("xAOD::TruthParticle", "child", ctyp.terminal('xAOD::TruthParticle', p_depth=1))
 
 
 class atlas_event_collection_coder(event_collection_coder):

--- a/func_adl_xAOD/atlas/xaod/event_collections.py
+++ b/func_adl_xAOD/atlas/xaod/event_collections.py
@@ -9,7 +9,7 @@ class atlas_xaod_event_collection_container(event_collection_container):
         super().__init__(type_name, is_pointer)
 
     def __str__(self):
-        return f"const {self._type_name} *"
+        return f"const {self.type} *"
 
 
 class atlas_xaod_event_collection_collection(event_collection_collection):
@@ -17,7 +17,7 @@ class atlas_xaod_event_collection_collection(event_collection_collection):
         super().__init__(type_name, element_name, is_type_pointer, is_element_pointer)
 
     def __str__(self):
-        return f"const {self._type_name}*"
+        return f"const {self.type}*"
 
 
 # all the collections types that are available. This is required because C++

--- a/func_adl_xAOD/atlas/xaod/event_collections.py
+++ b/func_adl_xAOD/atlas/xaod/event_collections.py
@@ -1,7 +1,7 @@
 import func_adl_xAOD.common.cpp_types as ctyp
 from func_adl_xAOD.common.event_collections import (
     EventCollectionSpecification, event_collection_coder,
-    event_collection_collection, event_collection_container)
+    event_collection_collection_container, event_collection_container)
 
 
 class atlas_xaod_event_collection_container(event_collection_container):
@@ -12,7 +12,7 @@ class atlas_xaod_event_collection_container(event_collection_container):
         return f"const {self.type} *"
 
 
-class atlas_xaod_event_collection_collection(event_collection_collection):
+class atlas_xaod_event_collection_collection(event_collection_collection_container):
     def __init__(self, type_name, element_name, is_type_pointer=True, is_element_pointer=True):
         super().__init__(type_name, element_name, is_type_pointer, is_element_pointer)
 

--- a/func_adl_xAOD/atlas/xaod/local_dataset.py
+++ b/func_adl_xAOD/atlas/xaod/local_dataset.py
@@ -12,7 +12,7 @@ class xAODDataset(LocalDataset):
     def __init__(self,
                  files: Union[Path, str, List[Path], List[str]],
                  docker_image: str = 'atlas/analysisbase',
-                 docker_tag: str = '21.2.191',
+                 docker_tag: str = '21.2.197',
                  output_directory: Optional[Path] = None):
         '''Run on the given files
 
@@ -20,6 +20,9 @@ class xAODDataset(LocalDataset):
             files (Path): Locally accessible files we are going to run on
             docker_image (str): The docker image name to run the executable
             docker_tag (str): The docker tag to use to run the executable
+
+        Note:
+            * (R21 Release Notes)[https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/AnalysisBaseReleaseNotes21_2]
         '''
         super().__init__(files, docker_image, docker_tag, output_directory)
 

--- a/func_adl_xAOD/atlas/xaod/query_ast_visitor.py
+++ b/func_adl_xAOD/atlas/xaod/query_ast_visitor.py
@@ -35,8 +35,7 @@ class atlas_xaod_query_ast_visitor(query_ast_visitor):
 
     def __init__(self):
         prefix = 'atlas_xaod'
-        is_loop_var_a_ref = False
-        super().__init__(prefix, is_loop_var_a_ref)
+        super().__init__(prefix)
 
     def create_book_ttree_obj(self, tree_name: str, leaves: list) -> book_ttree:
         return book_xaod_ttree(tree_name, leaves)

--- a/func_adl_xAOD/cms/aod/__init__.py
+++ b/func_adl_xAOD/cms/aod/__init__.py
@@ -2,5 +2,5 @@ from .cms_functions import isNonnull  # NOQA
 try:
     import python_on_whales  # NOQA
     from .local_dataset import CMSRun1AODDataset  # NOQA
-except ImportError:
+except ImportError:  # pragma: no cover
     pass

--- a/func_adl_xAOD/cms/aod/event_collections.py
+++ b/func_adl_xAOD/cms/aod/event_collections.py
@@ -17,7 +17,7 @@ class cms_aod_event_collection_collection(event_collection_collection):
         super().__init__(type_name, element_name, is_type_pointer, is_element_pointer)
 
     def __str__(self):
-        return f"edm::Handle<{self._type_name}>"
+        return f"edm::Handle<{self.type}>"
 
 
 # all the collections types that are available. This is required because C++

--- a/func_adl_xAOD/cms/aod/event_collections.py
+++ b/func_adl_xAOD/cms/aod/event_collections.py
@@ -1,20 +1,18 @@
+from typing import Union
 import func_adl_xAOD.common.cpp_types as ctyp
 from func_adl_xAOD.common.event_collections import (
     EventCollectionSpecification, event_collection_coder, event_collection_collection_container, event_collection_container)
 
 
-# class cms_aod_event_collection_container(event_collection_container):
-#     'There is nothing turned on here - till we have a real use case.'
-#     def __init__(self, type_name, is_pointer=True):
-#         super().__init__(type_name, is_pointer)
-
-#     def __str__(self):
-#         return f"edm::Handle<{self._type_name}>"
+# There is no use for a CMS single item collection - everything they have
+# has multiple items in it. Copy from the ATLAS example to get this working correctly.
 
 
 class cms_aod_event_collection_collection(event_collection_collection_container):
-    def __init__(self, type_name, element_name, is_type_pointer=True, is_element_pointer=True):
-        super().__init__(type_name, element_name, is_type_pointer, is_element_pointer)
+    def __init__(self, type_name: Union[str, ctyp.CPPParsedTypeInfo],
+                 element_name: Union[str, ctyp.CPPParsedTypeInfo],
+                 p_depth_type: int = 1, p_depth_element: int = 1):
+        super().__init__(type_name, element_name, p_depth_element=p_depth_element, p_depth_type=p_depth_type)
 
     def __str__(self):
         return f"edm::Handle<{self.type}>"
@@ -58,7 +56,7 @@ cms_aod_collections = [
                                  ["DataFormats/VertexReco/interface/Vertex.h",
                                   "DataFormats/VertexReco/interface/VertexFwd.h"
                                   ],
-                                 cms_aod_event_collection_collection('reco::VertexCollection', 'reco::Vertex', is_element_pointer=False),
+                                 cms_aod_event_collection_collection('reco::VertexCollection', 'reco::Vertex', p_depth_element=0),
                                  [],
                                  ),
     EventCollectionSpecification('cms', "GsfElectrons",

--- a/func_adl_xAOD/cms/aod/event_collections.py
+++ b/func_adl_xAOD/cms/aod/event_collections.py
@@ -76,17 +76,17 @@ def define_default_cms_types():
     'Define the default cms types'
     ctyp.add_method_type_info("reco::Track", "hitPattern", ctyp.terminal('reco::HitPattern'))
 
-    ctyp.add_method_type_info("reco::Muon", "globalTrack", ctyp.terminal('reco::Track', is_pointer=True))
+    ctyp.add_method_type_info("reco::Muon", "globalTrack", ctyp.terminal('reco::Track', p_depth=1))
     ctyp.add_method_type_info("reco::Muon", "hitPattern", ctyp.terminal('reco::HitPattern'))
     ctyp.add_method_type_info("reco::Muon", "isPFIsolationValid", ctyp.terminal('bool'))
     ctyp.add_method_type_info("reco::Muon", "isPFMuon", ctyp.terminal('bool'))
     ctyp.add_method_type_info("reco::Muon", "pfIsolationR04", ctyp.terminal('reco::MuonPFIsolation'))
 
-    ctyp.add_method_type_info("reco::GsfElectron", "gsfTrack", ctyp.terminal('reco::GsfTrack', is_pointer=True))
+    ctyp.add_method_type_info("reco::GsfElectron", "gsfTrack", ctyp.terminal('reco::GsfTrack', p_depth=1))
     ctyp.add_method_type_info("reco::GsfElectron", "isEB", ctyp.terminal('bool'))
     ctyp.add_method_type_info("reco::GsfElectron", "isEE", ctyp.terminal('bool'))
     ctyp.add_method_type_info("reco::GsfElectron", "passingPflowPreselection", ctyp.terminal('bool'))
-    ctyp.add_method_type_info("reco::GsfElectron", "superCluster", ctyp.terminal('reco::SuperClusterRef', is_pointer=True))
+    ctyp.add_method_type_info("reco::GsfElectron", "superCluster", ctyp.terminal('reco::SuperClusterRef', p_depth=1))
     ctyp.add_method_type_info("reco::GsfElectron", "pfIsolationVariables", ctyp.terminal('reco::GsfElectron::PflowIsolationVariables'))
 
     ctyp.add_method_type_info("reco::GsfTrack", "trackerExpectedHitsInner", ctyp.terminal('reco::HitPattern'))  # reco::HitPattern is the expected return type

--- a/func_adl_xAOD/cms/aod/event_collections.py
+++ b/func_adl_xAOD/cms/aod/event_collections.py
@@ -11,7 +11,7 @@ from func_adl_xAOD.common.event_collections import (
 class cms_aod_event_collection_collection(event_collection_collection_container):
     def __init__(self, type_name: Union[str, ctyp.CPPParsedTypeInfo],
                  element_name: Union[str, ctyp.CPPParsedTypeInfo],
-                 p_depth_type: int = 1, p_depth_element: int = 1):
+                 p_depth_type: int = 1, p_depth_element: int = 0):
         super().__init__(type_name, element_name, p_depth_element=p_depth_element, p_depth_type=p_depth_type)
 
     def __str__(self):

--- a/func_adl_xAOD/cms/aod/event_collections.py
+++ b/func_adl_xAOD/cms/aod/event_collections.py
@@ -1,6 +1,6 @@
 import func_adl_xAOD.common.cpp_types as ctyp
 from func_adl_xAOD.common.event_collections import (
-    EventCollectionSpecification, event_collection_coder, event_collection_collection, event_collection_container)
+    EventCollectionSpecification, event_collection_coder, event_collection_collection_container, event_collection_container)
 
 
 # class cms_aod_event_collection_container(event_collection_container):
@@ -12,7 +12,7 @@ from func_adl_xAOD.common.event_collections import (
 #         return f"edm::Handle<{self._type_name}>"
 
 
-class cms_aod_event_collection_collection(event_collection_collection):
+class cms_aod_event_collection_collection(event_collection_collection_container):
     def __init__(self, type_name, element_name, is_type_pointer=True, is_element_pointer=True):
         super().__init__(type_name, element_name, is_type_pointer, is_element_pointer)
 

--- a/func_adl_xAOD/cms/aod/query_ast_visitor.py
+++ b/func_adl_xAOD/cms/aod/query_ast_visitor.py
@@ -35,8 +35,7 @@ class cms_aod_query_ast_visitor(query_ast_visitor):
 
     def __init__(self):
         prefix = 'cms_aod'
-        is_loop_var_a_ref = True
-        super().__init__(prefix, is_loop_var_a_ref)
+        super().__init__(prefix)
 
     def create_book_ttree_obj(self, tree_name: str, leaves: list) -> book_ttree:
         return book_cms_aod_ttree(tree_name, leaves)

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -1,6 +1,3 @@
-# Code to translate from a reduced AST into C++ code. This is done by traversing the
-# Python AST code.
-
 import ast
 import logging
 from abc import ABC, abstractmethod

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -89,7 +89,7 @@ def get_ttree_type(rep):
         return rep.cpp_type()
 
 
-def determine_type_mf(parent_type, function_name):
+def determine_type_mf(parent_type: ctyp.terminal, function_name):
     '''
     Determine the return type of the member function. Do our best to make
     an intelligent case when we can.
@@ -102,18 +102,18 @@ def determine_type_mf(parent_type, function_name):
         raise RuntimeError("Internal Error: Trying to call member function for a type we do not know!")
     # If we are doing one of the normal "terminals", then we can just bomb. This should not happen!
 
-    rtn_type = ctyp.method_type_info(str(parent_type), function_name)
+    t_parent = parent_type.type
+    rtn_type = ctyp.method_type_info(t_parent, function_name)
     if rtn_type is not None:
         return rtn_type
 
     # We didn't know it. Lets make a guess, and error out if we are clearly making a mistake.
     base_types = ['double', 'float', 'int']
-    s_parent_type = str(parent_type)
-    if s_parent_type in base_types:
+    if t_parent in base_types:
         raise xAODTranslationError(f'Unable to call method {function_name} on type {str(parent_type)}.')
 
     # Ok - we give up. Return a double.
-    logging.getLogger(__name__).warning(f"Warning: assuming that the method '{str(s_parent_type)}::{function_name}(...)' has return type 'double'. Use cpp_types.add_method_type_info to suppress (or correct) this warning.")
+    logging.getLogger(__name__).warning(f"Warning: assuming that the method '{str(t_parent)}::{function_name}(...)' has return type 'double'. Use cpp_types.add_method_type_info to suppress (or correct) this warning.")
     return ctyp.terminal('double')
 
 

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -113,7 +113,7 @@ def determine_type_mf(parent_type, function_name):
         raise xAODTranslationError(f'Unable to call method {function_name} on type {str(parent_type)}.')
 
     # Ok - we give up. Return a double.
-    logging.getLogger(__name__).warning(f"Warning: assuming that the method '{str(s_parent_type)}.{function_name}(...)' has return type 'double'. Use cpp_types.add_method_type_info to suppress (or correct) this warning.")
+    logging.getLogger(__name__).warning(f"Warning: assuming that the method '{str(s_parent_type)}::{function_name}(...)' has return type 'double'. Use cpp_types.add_method_type_info to suppress (or correct) this warning.")
     return ctyp.terminal('double')
 
 

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -294,7 +294,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         plug-in architecture. But for now, we will just assume everything looks like a vector. When
         it comes time for a new type, this is where it should go.
         '''
-        element_type = rep.cpp_type().element_type()
+        element_type = rep.cpp_type().element_type
         element_type = element_type.get_dereferenced_type() if self._is_loop_var_a_ref else element_type
         iterator_value = crep.cpp_value(unique_name("i_obj"), None, element_type)  # type: ignore
         l_statement = statement.loop(iterator_value, crep.dereference_var(rep), is_loop_var_a_ref=self._is_loop_var_a_ref)  # type: ignore

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -127,7 +127,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
     Drive the conversion to C++ from the top level query
     """
 
-    def __init__(self, prefix, is_loop_var_a_ref: bool):
+    def __init__(self, prefix):
         r'''
         Initialize the visitor.
         '''
@@ -135,7 +135,6 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         self._gc = generated_code()
         self._arg_stack = argument_stack()
         self._prefix = prefix
-        self._is_loop_var_a_ref = is_loop_var_a_ref
 
     def include_files(self):
         return self._gc.include_files()
@@ -296,16 +295,13 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         '''
         cpp_type = rep.cpp_type()
         assert isinstance(cpp_type, ctyp.collection)
-        if self._is_loop_var_a_ref and rep.cpp_type().is_a_pointer:
-            element_type = cpp_type.element_type.get_dereferenced_type()
-        else:
-            element_type = cpp_type.element_type
+        element_type = cpp_type.element_type
         iterator_value = crep.cpp_value(unique_name("i_obj"), None, element_type)  # type: ignore
 
         # It could be this should deref until p_depth is 0
         collection = crep.dereference_var(rep)
 
-        l_statement = statement.loop(iterator_value, collection, is_loop_var_a_ref=self._is_loop_var_a_ref)
+        l_statement = statement.loop(iterator_value, collection)
         self._gc.add_statement(l_statement)
         iterator_value.reset_scope(self._gc.current_scope())
 

--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -50,30 +50,10 @@ from __future__ import annotations
 # Others follow a similar line of reasoning.
 import ast
 import copy
-from typing import Optional, Union, cast
+from typing import Optional, TypeVar, Union, cast
 
 import func_adl_xAOD.common.cpp_types as ctyp
 from func_adl_xAOD.common.util_scope import gc_scope, gc_scope_top_level
-
-
-def dereference_var(v: cpp_value) -> cpp_value:
-    '''
-    If this is a pointer, return the object with the proper type (and a * to dereference it). Otherwise
-    just return the object itself.
-
-    NOTE: It might just return the object itself, not dereferencing it!
-    '''
-    if not v.cpp_type().is_pointer():
-        return v
-
-    # We will go under the covers and "fix" this.
-    new_v = copy.copy(v)
-    new_v._expression = "*" + new_v._expression
-
-    # There is only one type we current support here.
-    # Eventually this is going to get us into trouble.
-    new_v._cpp_type = new_v.cpp_type().get_dereferenced_type()
-    return new_v
 
 
 class dummy_ast(ast.AST):
@@ -307,3 +287,27 @@ def get_rep(node: ast.AST) -> cpp_rep_base:
     Get the representation of a node.
     '''
     return node.rep  # type: ignore
+
+
+# Allow dereference type for anything that is a value of some sort
+DT = TypeVar('DT', bound=cpp_value)
+
+
+def dereference_var(v: DT) -> DT:
+    '''
+    If this is a pointer, return the object with the proper type (and a * to dereference it). Otherwise
+    just return the object itself.
+
+    NOTE: It might just return the object itself, not dereferencing it!
+    '''
+    if not v.cpp_type().is_pointer():
+        return v
+
+    # We will go under the covers and "fix" this.
+    new_v = copy.copy(v)
+    new_v._expression = "*" + new_v._expression
+
+    # There is only one type we current support here.
+    # Eventually this is going to get us into trouble.
+    new_v._cpp_type = new_v.cpp_type().get_dereferenced_type()
+    return new_v

--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -199,7 +199,7 @@ class cpp_collection(cpp_value):
 
     def get_element_type(self):
         'Return the type of the element of the sequence'
-        return cast(ctyp.collection, self.cpp_type()).element_type()
+        return cast(ctyp.collection, self.cpp_type()).element_type
 
 
 class cpp_tuple(cpp_rep_base):

--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -56,10 +56,12 @@ import func_adl_xAOD.common.cpp_types as ctyp
 from func_adl_xAOD.common.util_scope import gc_scope, gc_scope_top_level
 
 
-def dereference_var(v: cpp_value):
+def dereference_var(v: cpp_value) -> cpp_value:
     '''
     If this is a pointer, return the object with the proper type (and a * to dereference it). Otherwise
     just return the object itself.
+
+    NOTE: It might just return the object itself, not dereferencing it!
     '''
     if not v.cpp_type().is_pointer():
         return v
@@ -70,7 +72,7 @@ def dereference_var(v: cpp_value):
 
     # There is only one type we current support here.
     # Eventually this is going to get us into trouble.
-    new_v._cpp_type = new_v._cpp_type.dereference()  # type: ignore
+    new_v._cpp_type = new_v.cpp_type().get_dereferenced_type()
     return new_v
 
 

--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -314,7 +314,7 @@ def dereference_var(v: DT) -> DT:
     return new_v
 
 
-def base_type_member_access(v: cpp_value) -> str:
+def base_type_member_access(v: cpp_value, extra_deref: int = 0) -> str:
     '''
     Turn a C++ object into a base reference suitable for
     a member access.
@@ -322,11 +322,15 @@ def base_type_member_access(v: cpp_value) -> str:
     obj f => f.
     obj *f => f->
     obj **f => (*f)->
+
+    v:            The object to access.
+    extra_deref:  The number of extra dereferences to apply.
     '''
     result = v.as_cpp()
-    for _ in range(1, v.cpp_type().p_depth):
+    depth = extra_deref + v.cpp_type().p_depth
+    for _ in range(1, depth):
         result = f'(*{result})'
-    if v.cpp_type().p_depth > 0:
+    if depth > 0:
         return f'{result}->'
     else:
         return f'{result}.'

--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -284,7 +284,7 @@ class cpp_sequence(cpp_rep_base):
 
     def cpp_type(self) -> ctyp.terminal:
         if self._type is None:
-            self._type = ctyp.collection(self._sequence.cpp_type().type)
+            self._type = ctyp.collection(self._sequence.cpp_type())
         return self._type
 
     def as_cpp(self):

--- a/func_adl_xAOD/common/cpp_types.py
+++ b/func_adl_xAOD/common/cpp_types.py
@@ -81,8 +81,12 @@ class terminal:
     def type(self) -> str:
         return self._type
 
-    def get_dereferenced_type(self):
-        return terminal(self._type, self.p_depth - 1) if self.p_depth > 0 else self
+    def get_dereferenced_type(self) -> terminal:
+        'Type after dereferencing it once. Will throw if this type cannot be dereferenced'
+        if self._p_depth == 0:
+            raise RuntimeError(f'Cannot dereference type {self}')
+
+        return terminal(self._type, self.p_depth - 1)
 
 
 class collection (terminal):
@@ -107,6 +111,7 @@ class collection (terminal):
         # And the element type we are representing
         self._element_type = element_type
 
+    # TODO: Turn into a property
     def element_type(self) -> terminal:
         'The type of element that this collection holds'
         return self._element_type

--- a/func_adl_xAOD/common/cpp_types.py
+++ b/func_adl_xAOD/common/cpp_types.py
@@ -68,7 +68,9 @@ class terminal:
     def __str__(self):
         return str(self.type) + '*' * self._p_depth
 
-    def is_pointer(self):
+    @property
+    def is_a_pointer(self) -> bool:
+        'Returns true if this terminal is a pointer'
         return self._p_depth > 0
 
     @property

--- a/func_adl_xAOD/common/cpp_types.py
+++ b/func_adl_xAOD/common/cpp_types.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
-from typing import Optional, Union
+
+import copy
 from dataclasses import dataclass
+from typing import Optional, Union
 
 
 @dataclass
@@ -86,7 +88,10 @@ class terminal:
         if self._p_depth == 0:
             raise RuntimeError(f'Cannot dereference type {self}')
 
-        return terminal(self._type, self.p_depth - 1)
+        # Do deep copy because this needs to work in subclasses.
+        new_t = copy.copy(self)
+        new_t._p_depth -= 1
+        return new_t
 
 
 class collection (terminal):

--- a/func_adl_xAOD/common/cpp_types.py
+++ b/func_adl_xAOD/common/cpp_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 
 @dataclass
@@ -129,10 +129,23 @@ class collection (terminal):
 # Manage types
 
 
-g_method_type_dict = {}
+@dataclass
+class MethodInvokeInfo:
+    'Method invocation info'
+
+    # The return type
+    r_type: terminal
+
+    # Number of dereferences to apply to the calling object. Normally zero.
+    # 0: obj.method()
+    # 1: obj->method(), etc.
+    deref_depth: int
 
 
-def add_method_type_info(type_string: str, method_name: str, t: terminal):
+g_method_type_dict: Dict[str, Dict[str, MethodInvokeInfo]] = {}
+
+
+def add_method_type_info(type_string: str, method_name: str, t: terminal, deref_depth: int = 0):
     '''
     Define a return type for a method
 
@@ -142,10 +155,10 @@ def add_method_type_info(type_string: str, method_name: str, t: terminal):
     '''
     if type_string not in g_method_type_dict:
         g_method_type_dict[type_string] = {}
-    g_method_type_dict[type_string][method_name] = t
+    g_method_type_dict[type_string][method_name] = MethodInvokeInfo(t, deref_depth)
 
 
-def method_type_info(type_string, method_name) -> Optional[terminal]:
+def method_type_info(type_string, method_name) -> Optional[MethodInvokeInfo]:
     '''
     Return the type of the method's return value
     '''

--- a/func_adl_xAOD/common/cpp_types.py
+++ b/func_adl_xAOD/common/cpp_types.py
@@ -112,6 +112,7 @@ class collection (terminal):
         self._element_type = element_type
 
     # TODO: Turn into a property
+    @property
     def element_type(self) -> terminal:
         'The type of element that this collection holds'
         return self._element_type

--- a/func_adl_xAOD/common/event_collections.py
+++ b/func_adl_xAOD/common/event_collections.py
@@ -53,7 +53,7 @@ class event_collection_collection(event_collection_container):
         self._is_element_pointer = is_element_pointer
 
     def element_type(self):
-        return ctyp.terminal(self._element_name, is_pointer=self._is_element_pointer)
+        return ctyp.terminal(self._element_name, p_depth=1 if self._is_element_pointer else 0)
 
     def dereference(self):
         'Return a new version of us that is not a pointer'

--- a/func_adl_xAOD/common/event_collections.py
+++ b/func_adl_xAOD/common/event_collections.py
@@ -12,8 +12,8 @@ from func_adl_xAOD.common.cpp_vars import unique_name
 
 class event_collection_container(ctyp.terminal, ABC):
     # TODO: is_pointer should not be here
-    def __init__(self, type_name, is_pointer):
-        super().__init__(type_name, p_depth=1 if is_pointer else 0)
+    def __init__(self, type_name: Union[str, ctyp.CPPParsedTypeInfo], p_depth: int):
+        super().__init__(type_name, p_depth=p_depth)
 
     @abstractmethod
     def __str__(self) -> str:
@@ -26,10 +26,12 @@ class event_collection_container(ctyp.terminal, ABC):
 
 
 class event_collection_collection_container(ctyp.collection, ABC):
-    def __init__(self, type_name, element_name, is_type_pointer, is_element_pointer):
+    def __init__(self, type_name: Union[str, ctyp.CPPParsedTypeInfo],
+                 element_name: Union[str, ctyp.CPPParsedTypeInfo],
+                 p_depth_type: int, p_depth_element: int):
         super().__init__(
-            ctyp.terminal(element_name, p_depth=1 if is_element_pointer else 0),
-            array_type=type_name, p_depth=1 if is_type_pointer else 0
+            ctyp.terminal(element_name, p_depth=p_depth_element),
+            array_type=type_name, p_depth=p_depth_type
         )
 
     @abstractmethod

--- a/func_adl_xAOD/common/event_collections.py
+++ b/func_adl_xAOD/common/event_collections.py
@@ -11,7 +11,6 @@ from func_adl_xAOD.common.cpp_vars import unique_name
 
 
 class event_collection_container(ctyp.terminal, ABC):
-    # TODO: is_pointer should not be here
     def __init__(self, type_name: Union[str, ctyp.CPPParsedTypeInfo], p_depth: int):
         super().__init__(type_name, p_depth=p_depth)
 

--- a/func_adl_xAOD/common/event_collections.py
+++ b/func_adl_xAOD/common/event_collections.py
@@ -25,7 +25,7 @@ class event_collection_container(ctyp.terminal, ABC):
         '''
 
 
-class event_collection_collection(ctyp.collection, ABC):
+class event_collection_collection_container(ctyp.collection, ABC):
     def __init__(self, type_name, element_name, is_type_pointer, is_element_pointer):
         super().__init__(
             ctyp.terminal(element_name, p_depth=1 if is_element_pointer else 0),
@@ -51,7 +51,7 @@ class EventCollectionSpecification:
     include_files: List[str]
 
     # The container information
-    container_type: Union[event_collection_container, event_collection_collection]
+    container_type: Union[event_collection_container, event_collection_collection_container]
 
     # List of libraries (e.g. ['xAODJet'])
     libraries: List[str]
@@ -79,7 +79,7 @@ class event_collection_coder(ABC):
         r.running_code += self.get_running_code(md.container_type)
         r.result = 'result'
 
-        if issubclass(type(md.container_type), event_collection_collection):
+        if issubclass(type(md.container_type), event_collection_collection_container):
             r.result_rep = lambda scope: crep.cpp_collection(unique_name(md.name.lower()), scope=scope, collection_type=md.container_type)  # type: ignore
         else:
             r.result_rep = lambda scope: crep.cpp_variable(unique_name(md.name.lower()), scope=scope, cpp_type=md.container_type)
@@ -90,7 +90,7 @@ class event_collection_coder(ABC):
         return call_node
 
     @abstractmethod
-    def get_running_code(self, container_type: Union[event_collection_container, event_collection_collection]) -> List[str]:
+    def get_running_code(self, container_type: Union[event_collection_container, event_collection_collection_container]) -> List[str]:
         '''Return the code that will extract the collection from the event object
 
         Args:

--- a/func_adl_xAOD/common/local_dataset.py
+++ b/func_adl_xAOD/common/local_dataset.py
@@ -133,17 +133,17 @@ class LocalDataset(EventDataset, ABC):
                         output += f'{stream_content.decode()}'
                     else:
                         output += f'(stderr) {stream_content.decode()}'
-                self._dump_info(logging.DEBUG, output, local_run_dir, f_spec.main_script)
+                self._dump_info(logging.DEBUG, output, local_run_dir, f_spec.main_script, self._docker_image)
 
             except python_on_whales.exceptions.DockerException as e:
-                self._dump_info(logging.ERROR, output, local_run_dir, f_spec.main_script)
+                self._dump_info(logging.ERROR, output, local_run_dir, f_spec.main_script, self._docker_image)
                 raise e
 
             # Now that we have run, we can pluck out the result.
             assert isinstance(f_spec.result_rep, cpp_ttree_rep), 'Unknown return type'
             return [_extract_result_TTree(f_spec.result_rep, local_run_dir, self._output_directory)]
 
-    def _dump_info(self, level, running_string: str, local_run_dir: Path, source_file_name: str):
+    def _dump_info(self, level, running_string: str, local_run_dir: Path, source_file_name: str, docker_image: str):
         '''Dump the logging info from a docker run.
 
         Args:
@@ -152,6 +152,7 @@ class LocalDataset(EventDataset, ABC):
         '''
         lg = logging.getLogger(__name__)
 
+        lg.log(level, f'Docker image and tag: {docker_image}')
         lg.log(level, 'Docker Output: ')
         _dump_split_string(running_string, lambda l: lg.log(level, f'  {l}'))
 

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -42,7 +42,10 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecifi
                 type_info_element = parse_type(md['return_type_element'])
                 type_info_collection = parse_type(md['return_type_collection']) if 'return_type_collection' in md else CPPParsedTypeInfo(f'std::vector<{type_info_element}>', 0)
                 term = collection(terminal(type_info_element), array_type=type_info_collection)
-            add_method_type_info(md['type_string'], md['method_name'], term)
+            d_count = 0
+            if 'deref_count' in md:
+                d_count = int(md['deref_count'])
+            add_method_type_info(md['type_string'], md['method_name'], term, d_count)
         elif md_type == 'include_files':
             spec = IncludeFileList(md['files'])
             cpp_funcs.append(spec)

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -12,16 +12,21 @@ class JobScriptSpecification:
     depends_on: List[str]
 
 
-def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecification, EventCollectionSpecification, JobScriptSpecification]]:
+@dataclass
+class IncludeFileList:
+    files: List[str]
+
+
+def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecification, EventCollectionSpecification, JobScriptSpecification, IncludeFileList]]:
     '''Process a list of metadata, in order.
 
     Args:
         md (List[Dict[str, str]]): The metadata to process
 
     Returns:
-        List[CPPCodeSpecification]: Any C++ functions that were defined in the metadata
+        List[X]: Metadata we've found
     '''
-    cpp_funcs: List[Union[CPPCodeSpecification, EventCollectionSpecification, JobScriptSpecification]] = []
+    cpp_funcs: List[Union[CPPCodeSpecification, EventCollectionSpecification, JobScriptSpecification, IncludeFileList]] = []
     for md in md_list:
         md_type = md.get('metadata_type')
         if md_type is None:
@@ -32,6 +37,9 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecifi
             term = terminal(md['return_type'], is_pointer=is_pointer) if 'return_type' in md \
                 else collection(terminal(md['return_type_element'], is_pointer=True), is_pointer=is_pointer, array_type=md['return_type_collection'] if 'return_type_collection' in md else None)
             add_method_type_info(md['type_string'], md['method_name'], term)
+        elif md_type == 'include_files':
+            spec = IncludeFileList(md['files'])
+            cpp_funcs.append(spec)
         elif md_type == 'add_job_script':
             spec = JobScriptSpecification(
                 name=md['name'],

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -41,7 +41,7 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecifi
             else:
                 type_info_element = parse_type(md['return_type_element'])
                 type_info_collection = parse_type(md['return_type_collection']) if 'return_type_collection' in md else CPPParsedTypeInfo(f'std::vector<{type_info_element}>', 0)
-                term = collection(terminal(type_info_element.name, p_depth=1), array_type=type_info_collection)
+                term = collection(terminal(type_info_element), array_type=type_info_collection)
             add_method_type_info(md['type_string'], md['method_name'], term)
         elif md_type == 'include_files':
             spec = IncludeFileList(md['files'])

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -1,6 +1,7 @@
 from func_adl_xAOD.common.event_collections import EventCollectionSpecification
 from func_adl_xAOD.common.cpp_ast import CPPCodeSpecification
 from func_adl_xAOD.common.cpp_types import add_method_type_info, collection, terminal
+from func_adl_xAOD.common.utils import CPPParsedTypeInfo, parse_type
 from typing import Any, Dict, List, Union
 from dataclasses import dataclass
 
@@ -33,9 +34,14 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecifi
             raise ValueError(f'Metadata is missing `metadata_type` info ({md})')
 
         if md_type == 'add_method_type_info':
-            is_pointer = md['is_pointer'].upper() == 'TRUE'
-            term = terminal(md['return_type'], is_pointer=is_pointer) if 'return_type' in md \
-                else collection(terminal(md['return_type_element'], is_pointer=True), is_pointer=is_pointer, array_type=md['return_type_collection'] if 'return_type_collection' in md else None)
+            if 'return_type' in md:
+                # Single return type
+                type_info = parse_type(md['return_type'])
+                term = terminal(type_info.name, is_pointer=type_info.pointer_depth > 0)
+            else:
+                type_info_element = parse_type(md['return_type_element'])
+                type_info_collection = parse_type(md['return_type_collection']) if 'return_type_collection' in md else CPPParsedTypeInfo(f'std::vector<{type_info_element}>', 0)
+                term = collection(terminal(type_info_element.name, is_pointer=True), is_pointer=type_info_collection.pointer_depth > 0, array_type=type_info_collection.name)
             add_method_type_info(md['type_string'], md['method_name'], term)
         elif md_type == 'include_files':
             spec = IncludeFileList(md['files'])

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -1,7 +1,7 @@
 from func_adl_xAOD.common.event_collections import EventCollectionSpecification
 from func_adl_xAOD.common.cpp_ast import CPPCodeSpecification
 from func_adl_xAOD.common.cpp_types import add_method_type_info, collection, terminal
-from func_adl_xAOD.common.utils import CPPParsedTypeInfo, parse_type
+from func_adl_xAOD.common.cpp_types import CPPParsedTypeInfo, parse_type
 from typing import Any, Dict, List, Union
 from dataclasses import dataclass
 
@@ -37,11 +37,11 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[Union[CPPCodeSpecifi
             if 'return_type' in md:
                 # Single return type
                 type_info = parse_type(md['return_type'])
-                term = terminal(type_info.name, is_pointer=type_info.pointer_depth > 0)
+                term = terminal(type_info.name, p_depth=type_info.pointer_depth)
             else:
                 type_info_element = parse_type(md['return_type_element'])
                 type_info_collection = parse_type(md['return_type_collection']) if 'return_type_collection' in md else CPPParsedTypeInfo(f'std::vector<{type_info_element}>', 0)
-                term = collection(terminal(type_info_element.name, is_pointer=True), is_pointer=type_info_collection.pointer_depth > 0, array_type=type_info_collection.name)
+                term = collection(terminal(type_info_element.name, p_depth=1), array_type=type_info_collection)
             add_method_type_info(md['type_string'], md['method_name'], term)
         elif md_type == 'include_files':
             spec = IncludeFileList(md['files'])

--- a/func_adl_xAOD/common/statement.py
+++ b/func_adl_xAOD/common/statement.py
@@ -68,8 +68,7 @@ class loop(block):
     'A for loop'
 
     def __init__(self, loop_var_rep: crep.cpp_value,
-                 collection_rep: crep.cpp_collection,
-                 is_loop_var_a_pntr=False, is_loop_var_a_ref=False):
+                 collection_rep: crep.cpp_collection):
         '''
         Create a new implicit for loop statement. A new var is created, and the scope is set to
         be the one down from here.
@@ -77,15 +76,10 @@ class loop(block):
         block.__init__(self)
         self._collection = collection_rep
         self._loop_variable = loop_var_rep
-        self._is_loop_var_a_pointer = is_loop_var_a_pntr
-        self._is_loop_var_a_reference = is_loop_var_a_ref
 
     def emit(self, e):
         'Emit a for loop enclosed by a block of code'
-        e.add_line("for (auto {0}{1} : {2})".format(
-            '*' if self._is_loop_var_a_pointer
-            else ('&' if self._is_loop_var_a_reference else ''),
-            self._loop_variable.as_cpp(), self._collection.as_cpp()))
+        e.add_line(f"for (auto &&{self._loop_variable.as_cpp()} : {self._collection.as_cpp()})")
         block.emit(self, e)
 
 

--- a/func_adl_xAOD/common/utils.py
+++ b/func_adl_xAOD/common/utils.py
@@ -1,5 +1,4 @@
 from typing import Dict, List
-from dataclasses import dataclass
 
 import func_adl_xAOD.common.cpp_types as ctyp
 
@@ -22,38 +21,3 @@ def most_accurate_type(type_list: List[ctyp.terminal]) -> ctyp.terminal:
 
     ordered = sorted(type_list, key=lambda t: _type_priority[t.type], reverse=True)
     return ordered[0]
-
-
-@dataclass
-class CPPParsedTypeInfo:
-    '''
-    A parsed type, with the type and whether it's a pointer.
-    '''
-    # The type name (`int`, `vector<float`, etc.)
-    name: str
-
-    # Pointer, and how many (2 for `int**`, 0 for `int`, etc.)
-    pointer_depth: int
-
-    def __str__(self):
-        return self.name + '*' * self.pointer_depth
-
-def parse_type(t_name: str) -> CPPParsedTypeInfo:
-    '''Convert a type name string into info for a type
-
-    Args:
-        t_name (str): The type name (`float`, `float*`)
-
-    Returns:
-        CPPParsedTypeInfo: Parsed info from the type
-    '''
-    ptr_depth = 0
-    while True:
-        t_name = t_name.strip()
-        if t_name.endswith('*'):
-            ptr_depth += 1
-            t_name = t_name[:-1]
-        else:
-            break
-
-    return CPPParsedTypeInfo(t_name, ptr_depth)

--- a/func_adl_xAOD/common/utils.py
+++ b/func_adl_xAOD/common/utils.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+from dataclasses import dataclass
 
 import func_adl_xAOD.common.cpp_types as ctyp
 
@@ -21,3 +22,38 @@ def most_accurate_type(type_list: List[ctyp.terminal]) -> ctyp.terminal:
 
     ordered = sorted(type_list, key=lambda t: _type_priority[t.type], reverse=True)
     return ordered[0]
+
+
+@dataclass
+class CPPParsedTypeInfo:
+    '''
+    A parsed type, with the type and whether it's a pointer.
+    '''
+    # The type name (`int`, `vector<float`, etc.)
+    name: str
+
+    # Pointer, and how many (2 for `int**`, 0 for `int`, etc.)
+    pointer_depth: int
+
+    def __str__(self):
+        return self.name + '*' * self.pointer_depth
+
+def parse_type(t_name: str) -> CPPParsedTypeInfo:
+    '''Convert a type name string into info for a type
+
+    Args:
+        t_name (str): The type name (`float`, `float*`)
+
+    Returns:
+        CPPParsedTypeInfo: Parsed info from the type
+    '''
+    ptr_depth = 0
+    while True:
+        t_name = t_name.strip()
+        if t_name.endswith('*'):
+            ptr_depth += 1
+            t_name = t_name[:-1]
+        else:
+            break
+
+    return CPPParsedTypeInfo(t_name, ptr_depth)

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -6,7 +6,7 @@ import tempfile
 from collections import namedtuple
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 import pytest
 from func_adl import EventDataset

--- a/tests/atlas/xaod/test_integrated_query.py
+++ b/tests/atlas/xaod/test_integrated_query.py
@@ -92,8 +92,6 @@ def test_simple_dict_output():
 def test_md_job_options():
     '''Run object corrections as we go
     Based on the following code:
-
-
     '''
     training_df = as_pandas(f_single
                             .MetaData({

--- a/tests/atlas/xaod/test_simple_type_info.py
+++ b/tests/atlas/xaod/test_simple_type_info.py
@@ -18,7 +18,7 @@ def test_cant_call_double():
 
 
 def test_can_call_prodVtx():
-    ctyp.add_method_type_info("xAOD::TruthParticle", "prodVtx", ctyp.terminal('xAODTruth::TruthVertex', is_pointer=True))
+    ctyp.add_method_type_info("xAOD::TruthParticle", "prodVtx", ctyp.terminal('xAODTruth::TruthVertex', p_depth=1))
     atlas_xaod_dataset("file://root.root") \
         .Select("lambda e: e.TruthParticles('TruthParticles').Select(lambda t: t.prodVtx().x()).Sum()") \
         .value()
@@ -26,7 +26,7 @@ def test_can_call_prodVtx():
 
 def test_collection_return():
     'Make sure we can set and deal with a returned collection properly'
-    ctyp.add_method_type_info("xAOD::TruthParticle", "vertexes", ctyp.collection(ctyp.terminal('double'), is_pointer=False))
+    ctyp.add_method_type_info("xAOD::TruthParticle", "vertexes", ctyp.collection(ctyp.terminal('double'), p_depth=1))
     (atlas_xaod_dataset("file://root.root")
      .SelectMany(lambda e: e.TruthParticles('TruthParticles'))
      .SelectMany(lambda t: t.vertexes())

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -672,6 +672,49 @@ def test_metadata_job_options():
     assert len(r._job_option_blocks) == 1
 
 
+def test_metadata_returned_type():
+    # The following statement should be a straight sequence, not an array.
+    r = (atlas_xaod_dataset()
+         .MetaData({
+                   'metadata_type': 'add_method_type_info',
+                   'type_string': 'xAOD::Jet',
+                   'method_name': 'pt',
+                   'return_type': 'double',
+                   })
+         .SelectMany(lambda e: e.Jets("AntiKt4EMTopoJets"))
+         .Select(lambda j: j.pt() * 2)
+         .value()
+         )
+    # Check to see if there mention of push_back anywhere.
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+    value_ref = find_line_numbers_with('->pt()*2', lines)
+    assert len(value_ref) == 1
+
+
+def test_metadata_returned_type_deref():
+    # The following statement should be a straight sequence, not an array.
+    r = (atlas_xaod_dataset()
+         .MetaData({
+                   'metadata_type': 'add_method_type_info',
+                   'type_string': 'xAOD::Jet',
+                   'method_name': 'pt',
+                   'return_type': 'double',
+                   'deref_count': 1,
+                   })
+         .SelectMany(lambda e: e.Jets("AntiKt4EMTopoJets"))
+         .Select(lambda j: j.pt() * 2)
+         .value()
+         )
+    # Check to see if there mention of push_back anywhere.
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+    value_ref = find_line_numbers_with('->pt()*2', lines)
+    assert len(value_ref) == 1
+    ref_line = lines[value_ref[0]]
+    assert '(*i_obj' in ref_line
+
+
 def test_metadata_returned_collection():
     # The following statement should be a straight sequence, not an array.
     r = (atlas_xaod_dataset()

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -672,6 +672,62 @@ def test_metadata_job_options():
     assert len(r._job_option_blocks) == 1
 
 
+def test_metadata_returned_collection():
+    # The following statement should be a straight sequence, not an array.
+    r = (atlas_xaod_dataset()
+         .MetaData({
+                   'metadata_type': 'add_method_type_info',
+                   'type_string': 'xAOD::Jet',
+                   'method_name': 'pt',
+                   'return_type_element': 'myobj',
+                   })
+         .MetaData({
+                   'metadata_type': 'add_method_type_info',
+                   'type_string': 'myobj',
+                   'method_name': 'value',
+                   'return_type': 'double',
+                   })
+         .SelectMany(lambda e: e.Jets("AntiKt4EMTopoJets"))
+         .SelectMany(lambda j: j.pt())
+         .Select(lambda pt: pt.value() * 2)
+         .value()
+         )
+    # Check to see if there mention of push_back anywhere.
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+    value_ref = find_line_numbers_with('.value()*2', lines)
+    assert len(value_ref) == 1
+
+
+def test_metadata_returned_collection_double_ptr():
+    # The following statement should be a straight sequence, not an array.
+    r = (atlas_xaod_dataset()
+         .MetaData({
+                   'metadata_type': 'add_method_type_info',
+                   'type_string': 'xAOD::Jet',
+                   'method_name': 'pt',
+                   'return_type_element': 'myobj**',
+                   })
+         .MetaData({
+                   'metadata_type': 'add_method_type_info',
+                   'type_string': 'myobj',
+                   'method_name': 'value',
+                   'return_type': 'double',
+                   })
+         .SelectMany(lambda e: e.Jets("AntiKt4EMTopoJets"))
+         .SelectMany(lambda j: j.pt())
+         .Select(lambda pt: pt.value() * 2)
+         .value()
+         )
+    # Check to see if there mention of push_back anywhere.
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+    value_ref = find_line_numbers_with(')->value()*2', lines)
+    assert len(value_ref) == 1
+    deref = find_line_numbers_with('(*', lines)
+    assert len(deref) == 1
+
+
 def test_event_collection_too_many_arg():
     'This is integration testing - making sure the dict to root conversion works'
     with pytest.raises(ValueError) as e:

--- a/tests/common/test_cpp_representation.py
+++ b/tests/common/test_cpp_representation.py
@@ -159,3 +159,8 @@ def test_member_access_obj_ptr():
 def test_member_access_obj_ptr_ptr():
     cv = crep.cpp_value('f', gc_scope_top_level(), ctyp.terminal(ctyp.parse_type('obj**')))
     assert crep.base_type_member_access(cv) == '(*f)->'
+
+
+def test_member_access_obj_depth_1():
+    cv = crep.cpp_value('f', gc_scope_top_level(), ctyp.terminal(ctyp.parse_type('obj')))
+    assert crep.base_type_member_access(cv, 2) == '(*f)->'

--- a/tests/common/test_cpp_representation.py
+++ b/tests/common/test_cpp_representation.py
@@ -86,3 +86,31 @@ def test_sequence_type_2():
     seq_array = crep.cpp_sequence(seq, i_value, tc)
 
     assert seq_array.sequence_value().cpp_type().type == 'std::vector<int>'
+
+
+def test_deref_simple_ptr():
+    tc = gc_scope_top_level()
+    expr = "a"
+    c_type = ctyp.terminal('int', 1)
+
+    v = crep.cpp_variable(expr, tc, c_type)
+
+    d = crep.dereference_var(v)
+
+    assert d.cpp_type().type == 'int'
+    assert d.cpp_type().p_depth == 0
+    assert d.as_cpp() == '*a'
+
+
+def test_deref_simple_no_ptr():
+    tc = gc_scope_top_level()
+    expr = "a"
+    c_type = ctyp.terminal('int', 0)
+
+    v = crep.cpp_variable(expr, tc, c_type)
+
+    d = crep.dereference_var(v)
+
+    assert d.cpp_type().type == 'int'
+    assert d.cpp_type().p_depth == 0
+    assert d.as_cpp() == 'a'

--- a/tests/common/test_cpp_representation.py
+++ b/tests/common/test_cpp_representation.py
@@ -8,7 +8,7 @@ def test_expression_pointer_decl():
     e2 = crep.cpp_value("dude", top_level_scope(), ctyp.terminal("int"))
     assert not e2.is_pointer()
 
-    e3 = crep.cpp_value("dude", top_level_scope(), ctyp.terminal("int", is_pointer=True))
+    e3 = crep.cpp_value("dude", top_level_scope(), ctyp.terminal("int", p_depth=1))
     assert e3.is_pointer()
 
 
@@ -62,7 +62,9 @@ def test_variable_type__with_initial_update():
     v.update_type(ctyp.terminal('float', False))
 
     assert v.cpp_type().type == 'float'
-    assert v.initial_value().cpp_type().type == 'float'
+    iv = v.initial_value()
+    assert iv is not None
+    assert iv.cpp_type().type == 'float'
 
 
 def test_sequence_type():

--- a/tests/common/test_cpp_representation.py
+++ b/tests/common/test_cpp_representation.py
@@ -114,3 +114,33 @@ def test_deref_simple_no_ptr():
     assert d.cpp_type().type == 'int'
     assert d.cpp_type().p_depth == 0
     assert d.as_cpp() == 'a'
+
+
+def test_deref_collection():
+    tc = gc_scope_top_level()
+
+    c_type = ctyp.collection(ctyp.terminal(ctyp.parse_type('int')), ctyp.parse_type('vector<int>'))
+    c = crep.cpp_collection('my_var', tc, c_type)
+
+    d = crep.dereference_var(c)
+
+    assert isinstance(d, crep.cpp_collection)
+    cpp_type = d.cpp_type()
+    assert isinstance(cpp_type, ctyp.collection)
+    assert str(cpp_type) == 'vector<int>'
+    assert str(cpp_type.element_type) == 'int'
+
+
+def test_deref_collection_ptr():
+    tc = gc_scope_top_level()
+
+    c_type = ctyp.collection(ctyp.terminal(ctyp.parse_type('int')), ctyp.parse_type('vector<int>*'))
+    c = crep.cpp_collection('my_var', tc, c_type)
+
+    d = crep.dereference_var(c)
+
+    assert isinstance(d, crep.cpp_collection)
+    cpp_type = d.cpp_type()
+    assert isinstance(cpp_type, ctyp.collection)
+    assert str(cpp_type) == 'vector<int>'
+    assert str(cpp_type.element_type) == 'int'

--- a/tests/common/test_cpp_representation.py
+++ b/tests/common/test_cpp_representation.py
@@ -6,10 +6,10 @@ from func_adl_xAOD.common.util_scope import gc_scope_top_level, top_level_scope
 
 def test_expression_pointer_decl():
     e2 = crep.cpp_value("dude", top_level_scope(), ctyp.terminal("int"))
-    assert not e2.is_pointer()
+    assert e2.p_depth == 0
 
     e3 = crep.cpp_value("dude", top_level_scope(), ctyp.terminal("int", p_depth=1))
-    assert e3.is_pointer()
+    assert e3.p_depth == 1
 
 
 def test_cpp_value_as_str():
@@ -33,17 +33,17 @@ def test_variable_type_update():
 
 
 def test_variable_pointer():
-    'Make sure is_pointer can deal with a non-type correctly'
+    'Make sure p_depth can deal with a non-type correctly'
     v1 = crep.cpp_value('dude', top_level_scope(), ctyp.terminal('int'))
     v2 = crep.cpp_value('dude', top_level_scope(), None)
 
-    assert not v1.is_pointer()
+    assert v1.p_depth == 0
     with pytest.raises(RuntimeError):
-        v2.is_pointer()
+        v2.p_depth
 
 
 def test_variable_pointer_2():
-    'Make sure is_pointer can deal with a non-type correctly'
+    'Make sure p_depth can deal with a non-type correctly'
     v1 = crep.cpp_value('dude', top_level_scope(), ctyp.terminal('int'))
     v2 = crep.cpp_value('dude', top_level_scope(), None)
 
@@ -144,3 +144,18 @@ def test_deref_collection_ptr():
     assert isinstance(cpp_type, ctyp.collection)
     assert str(cpp_type) == 'vector<int>'
     assert str(cpp_type.element_type) == 'int'
+
+
+def test_member_access_obj():
+    cv = crep.cpp_value('f', gc_scope_top_level(), ctyp.terminal(ctyp.parse_type('obj')))
+    assert crep.base_type_member_access(cv) == 'f.'
+
+
+def test_member_access_obj_ptr():
+    cv = crep.cpp_value('f', gc_scope_top_level(), ctyp.terminal(ctyp.parse_type('obj*')))
+    assert crep.base_type_member_access(cv) == 'f->'
+
+
+def test_member_access_obj_ptr_ptr():
+    cv = crep.cpp_value('f', gc_scope_top_level(), ctyp.terminal(ctyp.parse_type('obj**')))
+    assert crep.base_type_member_access(cv) == '(*f)->'

--- a/tests/common/test_cpp_types.py
+++ b/tests/common/test_cpp_types.py
@@ -34,7 +34,9 @@ def test_no_method_type_found():
 
 def test_method_type_found():
     ctyp.add_method_type_info("bogus", "pt", ctyp.terminal('double'))
-    assert 'double' == str(ctyp.method_type_info("bogus", "pt"))
+    r = ctyp.method_type_info("bogus", "pt")
+    assert r is not None
+    assert 'double' == str(r.r_type)
 
 
 def test_terminal_type():

--- a/tests/common/test_cpp_types.py
+++ b/tests/common/test_cpp_types.py
@@ -42,6 +42,14 @@ def test_method_type_found():
 def test_terminal_type():
     t = ctyp.terminal('double', False)
     assert t.type == 'double'
+    assert str(t) == 'double'
+    assert not t.is_const
+
+
+def test_terminal_type_const():
+    t = ctyp.terminal('double', False, True)
+    assert t.is_const
+    assert str(t) == 'const double'
 
 
 def test_terminal_from_parse():
@@ -80,6 +88,14 @@ def test_parse_type_int():
     t = ctyp.parse_type('int')
     assert t.name == 'int'
     assert t.pointer_depth == 0
+    assert not t.is_const
+
+
+def test_parse_type_const_int():
+    t = ctyp.parse_type('const int')
+    assert t.name == 'int'
+    assert t.pointer_depth == 0
+    assert t.is_const
 
 
 def test_parse_type_int_sp():

--- a/tests/common/test_cpp_types.py
+++ b/tests/common/test_cpp_types.py
@@ -1,4 +1,5 @@
 import func_adl_xAOD.common.cpp_types as ctyp
+import pytest
 
 
 def test_int():
@@ -7,10 +8,24 @@ def test_int():
     assert not t_int.is_a_pointer
 
 
+def test_int_deref():
+    t_int = ctyp.terminal('int')
+    with pytest.raises(RuntimeError) as e:
+        t_int.get_dereferenced_type()
+
+    assert "dereference type int" in str(e.value)
+
+
 def test_int_pointer():
     t_int = ctyp.terminal('int', p_depth=1)
     assert t_int.p_depth == 1
     assert t_int.is_a_pointer
+
+
+def test_int_pointer_deref():
+    t_int = ctyp.terminal('int', p_depth=1)
+    t = t_int.get_dereferenced_type()
+    assert str(t) == 'int'
 
 
 def test_no_method_type_found():

--- a/tests/common/test_cpp_types.py
+++ b/tests/common/test_cpp_types.py
@@ -3,12 +3,14 @@ import func_adl_xAOD.common.cpp_types as ctyp
 
 def test_int():
     t_int = ctyp.terminal('int')
-    assert t_int.is_pointer() is False
+    assert t_int.p_depth == 0
+    assert not t_int.is_a_pointer
 
 
 def test_int_pointer():
     t_int = ctyp.terminal('int', p_depth=1)
-    assert t_int.is_pointer() is True
+    assert t_int.p_depth == 1
+    assert t_int.is_a_pointer
 
 
 def test_no_method_type_found():
@@ -29,14 +31,14 @@ def test_terminal_from_parse():
     t = ctyp.terminal(ctyp.parse_type('double'))
 
     assert t.type == 'double'
-    assert t.is_pointer() is False
+    assert t.is_a_pointer is False
 
 
 def test_terminal_from_parse_ptr():
     t = ctyp.terminal(ctyp.parse_type('double*'))
 
     assert t.type == 'double'
-    assert t.is_pointer() is True
+    assert t.p_depth == 1
 
 
 def test_collection():

--- a/tests/common/test_cpp_types.py
+++ b/tests/common/test_cpp_types.py
@@ -1,11 +1,14 @@
-# Test the cpp representations. These objects are quite simple, so there
-# aren't that many tests. Mostly when bugs are found something gets added here.
 import func_adl_xAOD.common.cpp_types as ctyp
 
 
-def test_int_pointer():
+def test_int():
     t_int = ctyp.terminal('int')
     assert t_int.is_pointer() is False
+
+
+def test_int_pointer():
+    t_int = ctyp.terminal('int', p_depth=1)
+    assert t_int.is_pointer() is True
 
 
 def test_no_method_type_found():
@@ -22,11 +25,73 @@ def test_terminal_type():
     assert t.type == 'double'
 
 
+def test_terminal_from_parse():
+    t = ctyp.terminal(ctyp.parse_type('double'))
+
+    assert t.type == 'double'
+    assert t.is_pointer() is False
+
+
+def test_terminal_from_parse_ptr():
+    t = ctyp.terminal(ctyp.parse_type('double*'))
+
+    assert t.type == 'double'
+    assert t.is_pointer() is True
+
+
 def test_collection():
-    c = ctyp.collection('double', False)
+    c = ctyp.collection(ctyp.terminal('double'), p_depth=0)
     assert c.type == 'std::vector<double>'
+    assert c.p_depth == 0
 
 
 def test_collection_with_arr_type():
-    c = ctyp.collection('double', False, 'VectorOfFloats')
+    c = ctyp.collection(ctyp.terminal('double'), 'VectorOfFloats', 0)
     assert c.type == 'VectorOfFloats'
+    assert c.p_depth == 0
+
+
+def test_collection_with_arr_type_parsed():
+    c = ctyp.collection(ctyp.terminal('double'), ctyp.parse_type('VectorOfFloats*'))
+    assert c.type == 'VectorOfFloats'
+    assert c.p_depth == 1
+
+
+def test_parse_type_int():
+    t = ctyp.parse_type('int')
+    assert t.name == 'int'
+    assert t.pointer_depth == 0
+
+
+def test_parse_type_int_sp():
+    t = ctyp.parse_type(' int  ')
+    assert t.name == 'int'
+    assert t.pointer_depth == 0
+
+
+def test_parse_type_int_ptr():
+    t = ctyp.parse_type('int*')
+    assert t.name == 'int'
+    assert t.pointer_depth == 1
+
+
+def test_parse_type_int_ptr_sp():
+    t = ctyp.parse_type('int  *')
+    assert t.name == 'int'
+    assert t.pointer_depth == 1
+
+
+def test_parse_type_int_2ptr_sp():
+    t = ctyp.parse_type('int  *  *')
+    assert t.name == 'int'
+    assert t.pointer_depth == 2
+
+
+def test_parse_type_str():
+    t = ctyp.parse_type('string')
+    assert str(t) == 'string'
+
+
+def test_parse_type_str_ptr():
+    t = ctyp.parse_type('string *')
+    assert str(t) == 'string*'

--- a/tests/common/test_executor.py
+++ b/tests/common/test_executor.py
@@ -48,8 +48,8 @@ def test_metadata_method():
 
     t = method_type_info('my_namespace::obj', 'pT')
     assert t is not None
-    assert t.type == 'int'
-    assert not t.is_a_pointer
+    assert t.r_type.type == 'int'
+    assert not t.r_type.is_a_pointer
 
 
 def test_metadata_cpp_code():

--- a/tests/common/test_executor.py
+++ b/tests/common/test_executor.py
@@ -39,7 +39,6 @@ def test_metadata_method():
                          '"type_string": "my_namespace::obj", '
                          '"method_name": "pT", '
                          '"return_type": "int", '
-                         '"is_pointer": "False", '
                          '}), lambda e: e + 1)')
     a2 = parse_statement('Select(ds, lambda e: e + 1)')
 
@@ -50,7 +49,7 @@ def test_metadata_method():
     t = method_type_info('my_namespace::obj', 'pT')
     assert t is not None
     assert t.type == 'int'
-    assert t.is_pointer() is False
+    assert not t.is_a_pointer
 
 
 def test_metadata_cpp_code():

--- a/tests/common/test_executor.py
+++ b/tests/common/test_executor.py
@@ -96,3 +96,16 @@ def test_metadata_collection():
     call_obj = new_a1.args[1].body.func.value.func  # type: ignore
     assert isinstance(call_obj, CPPCodeValue)
     assert "dude" in "-".join(call_obj.running_code)
+
+
+def test_include_files():
+    'Make sure include files are properly dealt with'
+
+    a1 = parse_statement('Select(MetaData(ds, {'
+                         '"metadata_type": "include_files",'
+                         '"files": ["xAODEventInfo/EventInfo.h"],'
+                         '}), lambda e: e.crazy("fork").pT())')
+
+    exe = do_nothing_executor()
+    _ = exe.apply_ast_transformations(a1)
+    assert exe.include_files == ["xAODEventInfo/EventInfo.h"]

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -644,7 +644,7 @@ class dummy_ttree_fill(statement.ttree_fill):
 
 class dummy_query_ast_visitor(query_ast_visitor):
     def __init__(self):
-        super().__init__('dummy', False)
+        super().__init__('dummy')
 
     def create_book_ttree_obj(self, tree_name: str, leaves: list) -> statement.book_ttree:
         return dummy_book_ttree()

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -72,6 +72,7 @@ def test_md_method_type_double():
     assert t.is_pointer() is False
 
 
+@pytest.mark.skip(reason='Needs to be a pointer till we can get the type info')
 def test_md_method_type_collection():
     'Make sure a double can be set'
     metadata = [
@@ -94,6 +95,7 @@ def test_md_method_type_collection():
     assert t.is_pointer() is False
 
 
+@pytest.mark.skip(reason='Needs to be a pointer till we can get the type info')
 def test_md_method_type_collection_ptr():
     'Make sure a double can be set'
     metadata = [
@@ -116,6 +118,7 @@ def test_md_method_type_collection_ptr():
     assert t.is_pointer() is False
 
 
+@pytest.mark.skip(reason='Needs to be a pointer till we can get the type info')
 def test_md_method_type_custom_collection():
     'Make sure a double can be set'
     metadata = [

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -69,7 +69,7 @@ def test_md_method_type_double():
     t = method_type_info('my_namespace::obj', 'pT')
     assert t is not None
     assert t.type == 'double'
-    assert t.is_pointer() is False
+    assert not t.is_a_pointer
 
 
 @pytest.mark.skip(reason='Needs to be a pointer till we can get the type info')
@@ -92,7 +92,7 @@ def test_md_method_type_collection():
     assert t.type == 'std::vector<double>'
     assert isinstance(t.element_type, terminal)
     assert str(t.element_type) == 'double'
-    assert t.is_pointer() is False
+    assert not t.is_a_pointer
 
 
 @pytest.mark.skip(reason='Needs to be a pointer till we can get the type info')
@@ -115,7 +115,7 @@ def test_md_method_type_collection_ptr():
     assert t.type == 'std::vector<double*>'
     assert isinstance(t.element_type, terminal)
     assert str(t.element_type) == 'double'
-    assert t.is_pointer() is False
+    assert not t.is_a_pointer
 
 
 @pytest.mark.skip(reason='Needs to be a pointer till we can get the type info')
@@ -138,7 +138,7 @@ def test_md_method_type_custom_collection():
     assert isinstance(t, collection)
     assert t.type == 'MyCustomCollection'
     assert str(t.element_type) == 'double'
-    assert t.is_pointer() is False
+    assert not t.is_a_pointer
 
 
 def test_md_method_type_object_pointer():
@@ -157,7 +157,7 @@ def test_md_method_type_object_pointer():
     t = method_type_info('my_namespace::obj', 'vertex')
     assert t is not None
     assert t.type == 'my_namespace::vertex'
-    assert t.is_pointer() is True
+    assert t.is_a_pointer
 
 
 def test_with_method_call_with_type(caplog):

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -214,8 +214,8 @@ def test_md_atlas_collection():
     assert s.name == 'TruthParticles'
     assert s.include_files == ['file1.h', 'file2.h']
     assert isinstance(s.container_type, atlas_xaod_event_collection_collection)
-    assert s.container_type._element_name == 'xAOD::Electron'
-    assert s.container_type._type_name == 'xAOD::ElectronContainer'
+    assert s.container_type.element_type().type == 'xAOD::Electron'
+    assert s.container_type.type == 'xAOD::ElectronContainer'
     assert s.libraries == []
 
 
@@ -239,7 +239,7 @@ def test_md_atlas_collection_single_obj():
     assert s.name == 'EventInfo'
     assert s.include_files == ['xAODEventInfo/EventInfo.h']
     assert isinstance(s.container_type, atlas_xaod_event_collection_container)
-    assert s.container_type._type_name == 'xAOD::EventInfo'
+    assert s.container_type.type == 'xAOD::EventInfo'
     assert s.libraries == ['xAODEventInfo']
 
 
@@ -314,8 +314,8 @@ def test_md_cms_collection():
     assert s.name == 'Vertex'
     assert s.include_files == ['DataFormats/VertexReco/interface/Vertex.h']
     assert isinstance(s.container_type, cms_aod_event_collection_collection)
-    assert s.container_type._element_name == 'reco::Vertex'
-    assert s.container_type._type_name == 'reco::VertexCollection'
+    assert s.container_type.element_type().type == 'reco::Vertex'
+    assert s.container_type.type == 'reco::VertexCollection'
 
 
 def test_md_cms_collection_extra():

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -72,7 +72,6 @@ def test_md_method_type_double():
     assert not t.is_a_pointer
 
 
-@pytest.mark.skip(reason='Needs to be a pointer till we can get the type info')
 def test_md_method_type_collection():
     'Make sure a double can be set'
     metadata = [
@@ -95,8 +94,7 @@ def test_md_method_type_collection():
     assert not t.is_a_pointer
 
 
-@pytest.mark.skip(reason='Needs to be a pointer till we can get the type info')
-def test_md_method_type_collection_ptr():
+def test_md_method_type_collection_item_ptr():
     'Make sure a double can be set'
     metadata = [
         {
@@ -114,11 +112,11 @@ def test_md_method_type_collection_ptr():
     assert isinstance(t, collection)
     assert t.type == 'std::vector<double*>'
     assert isinstance(t.element_type, terminal)
-    assert str(t.element_type) == 'double'
+    assert str(t.element_type) == 'double*'
+    assert t.element_type.p_depth == 1
     assert not t.is_a_pointer
 
 
-@pytest.mark.skip(reason='Needs to be a pointer till we can get the type info')
 def test_md_method_type_custom_collection():
     'Make sure a double can be set'
     metadata = [
@@ -139,6 +137,26 @@ def test_md_method_type_custom_collection():
     assert t.type == 'MyCustomCollection'
     assert str(t.element_type) == 'double'
     assert not t.is_a_pointer
+
+
+def test_md_method_type_collection_ptr():
+    'Make sure a double can be set'
+    metadata = [
+        {
+            'metadata_type': 'add_method_type_info',
+            'type_string': 'my_namespace::obj',
+            'method_name': 'pT',
+            'return_type_element': 'double',
+            'return_type_collection': 'vector<double>*',
+        }
+    ]
+
+    process_metadata(metadata)
+
+    t = method_type_info('my_namespace::obj', 'pT')
+    assert t is not None
+    assert isinstance(t, collection)
+    assert t.is_a_pointer
 
 
 def test_md_method_type_object_pointer():

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -68,8 +68,30 @@ def test_md_method_type_double():
 
     t = method_type_info('my_namespace::obj', 'pT')
     assert t is not None
-    assert t.type == 'double'
-    assert not t.is_a_pointer
+    assert t.r_type.type == 'double'
+    assert not t.r_type.is_a_pointer
+    assert t.deref_depth == 0
+
+
+def test_md_method_type_double_deref():
+    'Make sure a double can be set'
+    metadata = [
+        {
+            'metadata_type': 'add_method_type_info',
+            'type_string': 'my_namespace::obj',
+            'method_name': 'pT',
+            'return_type': 'double',
+            'deref_count': 2,
+        }
+    ]
+
+    process_metadata(metadata)
+
+    t = method_type_info('my_namespace::obj', 'pT')
+    assert t is not None
+    assert t.r_type.type == 'double'
+    assert not t.r_type.is_a_pointer
+    assert t.deref_depth == 2
 
 
 def test_md_method_type_collection():
@@ -87,11 +109,11 @@ def test_md_method_type_collection():
 
     t = method_type_info('my_namespace::obj', 'pT')
     assert t is not None
-    assert isinstance(t, collection)
-    assert t.type == 'std::vector<double>'
-    assert isinstance(t.element_type, terminal)
-    assert str(t.element_type) == 'double'
-    assert not t.is_a_pointer
+    assert isinstance(t.r_type, collection)
+    assert t.r_type.type == 'std::vector<double>'
+    assert isinstance(t.r_type.element_type, terminal)
+    assert str(t.r_type.element_type) == 'double'
+    assert not t.r_type.is_a_pointer
 
 
 def test_md_method_type_collection_item_ptr():
@@ -109,12 +131,12 @@ def test_md_method_type_collection_item_ptr():
 
     t = method_type_info('my_namespace::obj', 'pT')
     assert t is not None
-    assert isinstance(t, collection)
-    assert t.type == 'std::vector<double*>'
-    assert isinstance(t.element_type, terminal)
-    assert str(t.element_type) == 'double*'
-    assert t.element_type.p_depth == 1
-    assert not t.is_a_pointer
+    assert isinstance(t.r_type, collection)
+    assert t.r_type.type == 'std::vector<double*>'
+    assert isinstance(t.r_type.element_type, terminal)
+    assert str(t.r_type.element_type) == 'double*'
+    assert t.r_type.element_type.p_depth == 1
+    assert not t.r_type.is_a_pointer
 
 
 def test_md_method_type_custom_collection():
@@ -133,10 +155,10 @@ def test_md_method_type_custom_collection():
 
     t = method_type_info('my_namespace::obj', 'pT')
     assert t is not None
-    assert isinstance(t, collection)
-    assert t.type == 'MyCustomCollection'
-    assert str(t.element_type) == 'double'
-    assert not t.is_a_pointer
+    assert isinstance(t.r_type, collection)
+    assert t.r_type.type == 'MyCustomCollection'
+    assert str(t.r_type.element_type) == 'double'
+    assert not t.r_type.is_a_pointer
 
 
 def test_md_method_type_collection_ptr():
@@ -155,8 +177,8 @@ def test_md_method_type_collection_ptr():
 
     t = method_type_info('my_namespace::obj', 'pT')
     assert t is not None
-    assert isinstance(t, collection)
-    assert t.is_a_pointer
+    assert isinstance(t.r_type, collection)
+    assert t.r_type.is_a_pointer
 
 
 def test_md_method_type_object_pointer():
@@ -174,8 +196,8 @@ def test_md_method_type_object_pointer():
 
     t = method_type_info('my_namespace::obj', 'vertex')
     assert t is not None
-    assert t.type == 'my_namespace::vertex'
-    assert t.is_a_pointer
+    assert t.r_type.type == 'my_namespace::vertex'
+    assert t.r_type.is_a_pointer
 
 
 def test_with_method_call_with_type(caplog):

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -11,7 +11,7 @@ from func_adl_xAOD.common.cpp_types import collection, method_type_info, termina
 from func_adl_xAOD.common.event_collections import (
     EventCollectionSpecification, event_collection_coder, event_collection_container)
 from func_adl_xAOD.common.executor import executor
-from func_adl_xAOD.common.meta_data import JobScriptSpecification, generate_script_block, process_metadata
+from func_adl_xAOD.common.meta_data import IncludeFileList, JobScriptSpecification, generate_script_block, process_metadata
 from tests.utils.base import dataset, dummy_executor  # type: ignore
 
 
@@ -148,6 +148,23 @@ def test_with_method_call_with_type(caplog):
      )
 
     assert 'pT' not in caplog.text
+
+
+def test_md_include_files():
+    'Add some include files'
+    metadata = [
+        {
+            'metadata_type': 'include_files',
+            'files': ['file1.h', 'file2.h'],
+        }
+    ]
+
+    result = process_metadata(metadata)
+
+    assert len(result) == 1
+    s = result[0]
+    assert isinstance(s, IncludeFileList)
+    assert s.files == ['file1.h', 'file2.h']
 
 
 def test_md_atlas_collection():

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -90,8 +90,8 @@ def test_md_method_type_collection():
     assert t is not None
     assert isinstance(t, collection)
     assert t.type == 'std::vector<double>'
-    assert isinstance(t.element_type(), terminal)
-    assert str(t.element_type()) == 'double'
+    assert isinstance(t.element_type, terminal)
+    assert str(t.element_type) == 'double'
     assert t.is_pointer() is False
 
 
@@ -113,8 +113,8 @@ def test_md_method_type_collection_ptr():
     assert t is not None
     assert isinstance(t, collection)
     assert t.type == 'std::vector<double*>'
-    assert isinstance(t.element_type(), terminal)
-    assert str(t.element_type()) == 'double'
+    assert isinstance(t.element_type, terminal)
+    assert str(t.element_type) == 'double'
     assert t.is_pointer() is False
 
 
@@ -137,7 +137,7 @@ def test_md_method_type_custom_collection():
     assert t is not None
     assert isinstance(t, collection)
     assert t.type == 'MyCustomCollection'
-    assert str(t.element_type()) == 'double'
+    assert str(t.element_type) == 'double'
     assert t.is_pointer() is False
 
 
@@ -214,7 +214,7 @@ def test_md_atlas_collection():
     assert s.name == 'TruthParticles'
     assert s.include_files == ['file1.h', 'file2.h']
     assert isinstance(s.container_type, atlas_xaod_event_collection_collection)
-    assert s.container_type.element_type().type == 'xAOD::Electron'
+    assert s.container_type.element_type.type == 'xAOD::Electron'
     assert s.container_type.type == 'xAOD::ElectronContainer'
     assert s.libraries == []
 
@@ -314,7 +314,7 @@ def test_md_cms_collection():
     assert s.name == 'Vertex'
     assert s.include_files == ['DataFormats/VertexReco/interface/Vertex.h']
     assert isinstance(s.container_type, cms_aod_event_collection_collection)
-    assert s.container_type.element_type().type == 'reco::Vertex'
+    assert s.container_type.element_type.type == 'reco::Vertex'
     assert s.container_type.type == 'reco::VertexCollection'
 
 

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -1,5 +1,5 @@
 import func_adl_xAOD.common.cpp_types as ctyp
-from func_adl_xAOD.common.utils import most_accurate_type, parse_type
+from func_adl_xAOD.common.utils import most_accurate_type
 
 
 def test_accurate_type_single_int():
@@ -33,43 +33,3 @@ def test_accurate_type_float_and_double():
     t2 = ctyp.terminal('float', False)
     r = most_accurate_type([t1, t2])
     assert r._type == 'double'
-
-
-def test_parse_type_int():
-    t = parse_type('int')
-    assert t.name == 'int'
-    assert t.pointer_depth == 0
-
-
-def test_parse_type_int_sp():
-    t = parse_type(' int  ')
-    assert t.name == 'int'
-    assert t.pointer_depth == 0
-
-
-def test_parse_type_int_ptr():
-    t = parse_type('int*')
-    assert t.name == 'int'
-    assert t.pointer_depth == 1
-
-
-def test_parse_type_int_ptr_sp():
-    t = parse_type('int  *')
-    assert t.name == 'int'
-    assert t.pointer_depth == 1
-
-
-def test_parse_type_int_2ptr_sp():
-    t = parse_type('int  *  *')
-    assert t.name == 'int'
-    assert t.pointer_depth == 2
-
-
-def test_parse_type_str():
-    t = parse_type('string')
-    assert str(t) == 'string'
-
-
-def test_parse_type_str_ptr():
-    t = parse_type('string *')
-    assert str(t) == 'string*'

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -1,5 +1,5 @@
 import func_adl_xAOD.common.cpp_types as ctyp
-from func_adl_xAOD.common.utils import most_accurate_type
+from func_adl_xAOD.common.utils import most_accurate_type, parse_type
 
 
 def test_accurate_type_single_int():
@@ -33,3 +33,43 @@ def test_accurate_type_float_and_double():
     t2 = ctyp.terminal('float', False)
     r = most_accurate_type([t1, t2])
     assert r._type == 'double'
+
+
+def test_parse_type_int():
+    t = parse_type('int')
+    assert t.name == 'int'
+    assert t.pointer_depth == 0
+
+
+def test_parse_type_int_sp():
+    t = parse_type(' int  ')
+    assert t.name == 'int'
+    assert t.pointer_depth == 0
+
+
+def test_parse_type_int_ptr():
+    t = parse_type('int*')
+    assert t.name == 'int'
+    assert t.pointer_depth == 1
+
+
+def test_parse_type_int_ptr_sp():
+    t = parse_type('int  *')
+    assert t.name == 'int'
+    assert t.pointer_depth == 1
+
+
+def test_parse_type_int_2ptr_sp():
+    t = parse_type('int  *  *')
+    assert t.name == 'int'
+    assert t.pointer_depth == 2
+
+
+def test_parse_type_str():
+    t = parse_type('string')
+    assert str(t) == 'string'
+
+
+def test_parse_type_str_ptr():
+    t = parse_type('string *')
+    assert str(t) == 'string*'


### PR DESCRIPTION
* Add metadata documentation to readme.md
* Add the `include_files` metadata type: allows one to add include files as needed
* Internal clean-up
  * Reorg how `ctyp.terminal` is used, making everything cleanly inherit from a common base class
  * Make the collections in ATLAS and CMS inherit rather than duck typing them
  * Remove some code differences between ATLAS/CMS now that `terminal` is more capable
  * Track pointer-to-pointer, not just pointer (and pointer-to-pointer-to-pointer, etc.)
* Metadata improvements around handling pointers inside collections