### PR TITLE
Fix First scoping bug

### DIFF
--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -162,7 +162,8 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         '''
         rep = getattr(node, 'rep', None)
         if rep is not None:
-            if not self._gc.current_scope().starts_with(rep.scope()):
+            rep_scope = getattr(node, 'scope', rep.scope())
+            if not self._gc.current_scope().starts_with(rep_scope):
                 rep = None
 
         if rep is None:
@@ -1093,6 +1094,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         source = args[0]
 
         # Make sure we are in a loop.
+        cs = self._gc.current_scope()
         seq = self.as_sequence(source)
 
         # The First terminal works by protecting the code with a if (first_time) {} block.
@@ -1125,4 +1127,4 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         # Otherwise return a new version of the value.
         first_value = sv if isinstance(sv, crep.cpp_sequence) else sv.copy_with_new_scope(self._gc.current_scope())
 
-        crep.set_rep(node, first_value)
+        crep.set_rep(node, first_value, cs)

--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 # Others follow a similar line of reasoning.
 import ast
 import copy
-from typing import Optional, TypeVar, Union, cast
+from typing import Any, Optional, TypeVar, Union, cast
 
 import func_adl_xAOD.common.cpp_types as ctyp
 from func_adl_xAOD.common.util_scope import gc_scope, gc_scope_top_level
@@ -276,11 +276,13 @@ class cpp_sequence(cpp_rep_base):
         return self._scope
 
 
-def set_rep(node: ast.AST, value: cpp_rep_base):
+def set_rep(node: ast.AST, value: cpp_rep_base, scope: Optional[Any] = None):
     '''
     Set the representation of a node to a value.
     '''
     node.rep = value  # type: ignore
+    if scope is not None:
+        node.scope = scope  # type: ignore
 
 
 def get_rep(node: ast.AST) -> cpp_rep_base:

--- a/func_adl_xAOD/template/atlas/r21/ATestRun_eljob.py
+++ b/func_adl_xAOD/template/atlas/r21/ATestRun_eljob.py
@@ -30,23 +30,6 @@ job.sampleHandler(sh)
 {{i}}
 {% endfor %}
 
-# Commented out for now because it really slows things down. Uncomment and change
-# the bank to be Analysis_NOSYS in query.cxx and it will work again.
-# #Get the systematics tool in - because we need it.
-# from AnaAlgorithm.AnaAlgorithmConfig import AnaAlgorithmConfig
-# config = AnaAlgorithmConfig( 'CP::SysListLoaderAlg/SysLoaderAlg' )
-# config.sigmaRecommended = 1
-# job.algsAdd( config )
-
-# # First step - run calibration for the jets so they are available to use when we want them.
-# ROOT.CP.JetCalibrationAlg ("dummy", None)
-# from JetAnalysisAlgorithms.JetAnalysisSequence import makeJetAnalysisSequence
-# #from jetsequence import makeJetAnalysisSequence
-# jetSequence = makeJetAnalysisSequence( 'data', "AntiKt4EMTopoJets" )
-# jetSequence.configure( inputName = "AntiKt4EMTopoJets", outputName = 'AnalysisJets' )
-# for alg in jetSequence:
-#     job.algsAdd(alg)
-
 # Create the algorithm's configuration.
 alg = createAlgorithm('query', 'AnalysisAlg')
 # later on we'll add some configuration options for our algorithm that go here


### PR DESCRIPTION
Fixes a bug in how `First`'s representation was getting scoped. When `First` was used with a `Select` that was looking for a dict of answers (e.g. reusing the `First` a few times), it would be invalidated and re-created.