### PR TITLE
Code Injection Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,21 +154,27 @@ For _cms_:
 | contains_collection | Some items are singletons (like `EventInfo`) | `True` or `False` |
 | element_pointer | Indicates if the element type is a pointer | `True` or `False` |
 
-#### Include Files
+#### Code Blocks
 
-Any include files listed will be added to the top of the `query.cpp` file that is generated. While ordering is maintained within a single `Metadata` query here, it is not maintained between different `Metadata` calls.
+Code blocks provide a way to inject various lines of C++ into code. There are a number of options, and any combinations of keys can be used.
 
-All includes are done with straight quotes:
-
-```C++
-#include "file1.hpp"
-#include "file2.hpp"
-```
 
 | Key | Description | Example |
 | ------------ | ------------ | --------------|
-| metadata_type | The metadata type | `"include_files"` |
-| files | List of files to include. | `["file1.hpp", "file2.hpp"]` |
+| metadata_type | The metadata type | `"inject_code"` |
+| body_includes | List of files to include in the C++ file (`query.cpp`). | `["file1.hpp", "file2.hpp"]` |
+| header_includes | List of files to include in the C++ header file (`query.hpp`). | `["file1.hpp", "file2.hpp"]` |
+| private_members | List of class instance variables to declare (`query.hpp`) | `["int first;", "int second;"]` |
+| instance_initialization | Initializers added to the constructor in the main C++ class file (`query.cpp`) | `["first(10)", "second(10)"]` |
+| ctor_lines | Lines of C++ to add to the body of the constructor (`query.cpp`) | `["second = first * 10;"]`
+| link_libraries | Items to add to the `CMake LINK_LIBRARIES` list (`CMakeLists.txt`) | `["TrigDecisionToolLib"]` |
+
+A few things to note:
+
+- Note the items that have semicolons and those that do not. This is crucial - the system will not add them in those cases!
+- While the ordering of lines withing a single `inject_code` metadata block will be maintained, different blocks may be reordered arbitrarily.
+- Include files always use the double-quote: `#include "file1.hpp"`
+
 
 ### Output Formats
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ the optional parameter `instance_obj` should be specified.
 | name | C++ Function Name | `"DeltaR"` |
 | include_files | List of include files | `[vector, TLorentzVector.h]` |
 | arguments | List of argument names | `[vec1, vec2]` |
-| code | List of code lines | `["auto t = (vec1+vec2);", "result = t.m();"]` |
-| instance_object | Present only if this is an object replacement. It species the code string that should be replaced by the current object | `"obj_j"` |
-| method_object | The object name that the method can be called on. Present only if this is a method. | `"xAOD::Jet_vt"` |
+| code | List of code lines | `["auto t = (vec1+vec2);", "auto result = t.m();"]` |
+| instance_object | Present only if this is an object replacement. It species the code string that should be replaced by the current object | `"xAOD::Jet_vt"` |
+| method_object | The object name that the method can be called on. Present only if this is a method. | `"obj_j"` |
 | result_name | If not using `result` what should be used (optional) | `"my_result"` |
 | return_type | C++ return type | `double` |
 | return_is_collection | If true, then the return is a collection of `return_type` | `True` |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ outside, and expected to be set somewhere inside the block.
 
 Note that a very simple replacement is done for `result_name` - so it needs to be a totally unique name. The back-end may well change `result` to some other name (like `r232`) depending on the complexity of the expression being parsed.
 
+If two functions are sent with the same name they must be identical or behavior is undefined.
+
 #### Job Scripts
 
 ATLAS runs job scripts to configure its environment. These are needed to do things like apply corrections, etc. This block allows those to be added on the fly. In ATLAS these jobs scripts are python.
@@ -158,10 +160,10 @@ For _cms_:
 
 Code blocks provide a way to inject various lines of C++ into code. There are a number of options, and any combinations of keys can be used.
 
-
 | Key | Description | Example |
 | ------------ | ------------ | --------------|
 | metadata_type | The metadata type | `"inject_code"` |
+| name | The name of the code block | `"code_block_1"` |
 | body_includes | List of files to include in the C++ file (`query.cpp`). | `["file1.hpp", "file2.hpp"]` |
 | header_includes | List of files to include in the C++ header file (`query.hpp`). | `["file1.hpp", "file2.hpp"]` |
 | private_members | List of class instance variables to declare (`query.hpp`) | `["int first;", "int second;"]` |
@@ -174,7 +176,7 @@ A few things to note:
 - Note the items that have semicolons and those that do not. This is crucial - the system will not add them in those cases!
 - While the ordering of lines withing a single `inject_code` metadata block will be maintained, different blocks may be reordered arbitrarily.
 - Include files always use the double-quote: `#include "file1.hpp"`
-
+- The name of the code block is not used anywhere, and it must be unique. If two code blocks are submitted with the same name but different contents it will generate an error.
 
 ### Output Formats
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ For a _collection_:
 | return_type_collection | The type of the collection | `vector<float>`, `vector<float>*` |
 | deref_count | Number of times to dereference object before invoking this method (optional) | 2 |
 
-#### C++ Inline Functions
+#### C++ Inline Functions and Methods
 
 These are inline functions - they are placed inline in the code, surrounded by a braces. Only the `result` is declared
-outside, and expected to be set somewhere inside the block.
+outside, and expected to be set somewhere inside the block. This mechanism can also specify a method. In that case
+the optional parameter `instance_obj` should be specified.
 
 | Key | Description | Example |
 | ------------ | ------------ | --------------|
@@ -107,8 +108,11 @@ outside, and expected to be set somewhere inside the block.
 | include_files | List of include files | `[vector, TLorentzVector.h]` |
 | arguments | List of argument names | `[vec1, vec2]` |
 | code | List of code lines | `["auto t = (vec1+vec2);", "result = t.m();"]` |
+| instance_object | Present only if this is an object replacement. It species the code string that should be replaced by the current object | `"obj_j"` |
+| method_object | The object name that the method can be called on. Present only if this is a method. | `"xAOD::Jet_vt"` |
 | result_name | If not using `result` what should be used (optional) | `"my_result"` |
 | return_type | C++ return type | `double` |
+| return_is_collection | If true, then the return is a collection of `return_type` | `True` |
 
 Note that a very simple replacement is done for `result_name` - so it needs to be a totally unique name. The back-end may well change `result` to some other name (like `r232`) depending on the complexity of the expression being parsed.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,38 @@ For a _collection_:
 | return_type_collection | The type of the collection | `vector<float>`, `vector<float>*` |
 | deref_count | Number of times to dereference object before invoking this method (optional) | 2 |
 
+#### C++ Inline Functions
+
+These are inline functions - they are placed inline in the code, surrounded by a braces. Only the `result` is declared
+outside, and expected to be set somewhere inside the block.
+
+| Key | Description | Example |
+| ------------ | ------------ | --------------|
+| metadata_type | The metadata type | `"add_cpp_function"` |
+| name | C++ Function Name | `"DeltaR"` |
+| include_files | List of include files | `[vector, TLorentzVector.h]` |
+| arguments | List of argument names | `[vec1, vec2]` |
+| code | List of code lines | `["auto t = (vec1+vec2);", "result = t.m();"]` |
+| result_name | If not using `result` what should be used (optional) | `"my_result"` |
+| return_type | C++ return type | `double` |
+
+Note that a very simple replacement is done for `result_name` - so it needs to be a totally unique name. The back-end may well change `result` to some other name (like `r232`) depending on the complexity of the expression being parsed.
+
+#### Job Scripts
+
+ATLAS runs job scripts to configure its environment. These are needed to do things like apply corrections, etc. This block allows those to be added on the fly. In ATLAS these jobs scripts are python.
+
+| Key | Description | Example |
+| ------------ | ------------ | --------------|
+| metadata_type | The metadata type | `"add_job_script"` |
+| name | Name of this script block | `"apply_corrections"` |
+| script | List of lines of python | `["calibration = makeAnalysis('mc')", "job.addSequence(calibration)"]` |
+| depends_on | List of other script blocks that this should come after | `["correction_setup"]` |
+
+A dependency graph is built from the `depends_on` entry, otherwise the blocks will appear in a random order.
+
+NOTE: Currently the CMS backend will ignore any job script metadata sent to it.
+
 #### Event Level Collections
 
 CMS and ATLAS store their basic reconstruction objects as collections (e.g. jets, etc.). You can define new collections on the fly with the following metadata

--- a/func_adl_xAOD/atlas/xaod/executor.py
+++ b/func_adl_xAOD/atlas/xaod/executor.py
@@ -16,7 +16,7 @@ class atlas_xaod_executor(executor):
         runner_name = 'runner.sh'
         template_dir_name = 'func_adl_xAOD/template/atlas/r21'
         self._ecc = atlas_event_collection_coder()
-        method_names = {
+        method_names: Dict[str, Callable[[ast.Call], ast.Call]] = {
             md.name: self.build_callback(self._ecc, md)
             for md in atlas_xaod_collections
         }

--- a/func_adl_xAOD/atlas/xaod/jets.py
+++ b/func_adl_xAOD/atlas/xaod/jets.py
@@ -2,57 +2,6 @@
 import ast
 
 import func_adl_xAOD.common.cpp_ast as cpp_ast
-import func_adl_xAOD.common.cpp_representation as crep
-import func_adl_xAOD.common.cpp_types as ctyp
-from func_adl_xAOD.common.cpp_vars import unique_name
-
-
-def getAttributeFloatAst(call_node: ast.Call):
-    r'''
-    Return an attribute on one of the xAOD objects.
-    '''
-    # Get the name of the moment out
-    if len(call_node.args) != 1:
-        raise Exception("Calling getAttributeFloat - only one argument is allowed")
-    if not isinstance(call_node.args[0], ast.Str):
-        raise Exception("Calling getAttributeFloat - only acceptable argument is a string")
-
-    r = cpp_ast.CPPCodeValue()
-    # We don't need include files for this - just quick access
-    r.args = ['moment_name', ]
-    r.replacement_instance_obj = ('obj_j', call_node.func.value.id)  # type: ignore
-    r.running_code += ['float result = obj_j->getAttribute<float>(moment_name);']
-    r.result = 'result'
-    r.result_rep = lambda sc: crep.cpp_variable(unique_name("jet_attrib"), scope=sc, cpp_type=ctyp.terminal('float'))
-
-    # Replace it as the function that is going to get called.
-    call_node.func = r  # type: ignore
-
-    return call_node
-
-
-def getAttributeVectorFloatAst(call_node: ast.Call):
-    r'''
-    Return a cpp ast accessing a vector of doubles for an xAOD attribute
-    '''
-    # Get the name of the moment out
-    if len(call_node.args) != 1:
-        raise Exception("Calling getAttributeVectorFloat - only one argument is allowed")
-    if not isinstance(call_node.args[0], ast.Str):
-        raise Exception("Calling getAttributeVectorFloat - only acceptable argument is a string")
-
-    r = cpp_ast.CPPCodeValue()
-    r.include_files += ['vector']
-    r.args = ['moment_name', ]
-    r.replacement_instance_obj = ('obj_j', call_node.func.value.id)  # type: ignore
-    r.running_code += ['auto result = obj_j->getAttribute<std::vector<double>>(moment_name);']
-    r.result = 'result'
-    r.result_rep = lambda sc: crep.cpp_collection(unique_name("jet_vec_attrib_"), scope=sc, collection_type=ctyp.collection(ctyp.terminal('double')))  # type: ignore
-
-    # Replace it as the function that is going to get called.
-    call_node.func = r  # type: ignore
-
-    return call_node
 
 
 def getAttribute(call_node: ast.Call):
@@ -64,8 +13,29 @@ def getAttribute(call_node: ast.Call):
 
 
 def get_jet_methods():
+    get_attribute_float = cpp_ast.CPPCodeSpecification(
+        name='getAttributeFloat',
+        include_files=['vector'],
+        arguments=['moment_name', ],
+        code=['auto result = obj_j->getAttribute<float>(moment_name);'],
+        result='result',
+        cpp_return_type='float',
+        method_object='obj_j',
+        instance_object='xAOD::Jet_v1',
+    )
+    get_attribute_vector_float = cpp_ast.CPPCodeSpecification(
+        name='getAttributeFloat',
+        include_files=['vector'],
+        arguments=['moment_name', ],
+        code=['auto result = obj_j->getAttribute<std::vector<double>>(moment_name);'],
+        result='result',
+        cpp_return_type='double',
+        cpp_return_is_collection=True,
+        method_object='obj_j',
+        instance_object='xAOD::Jet_v1',
+    )
     return {
         'getAttribute': getAttribute,
-        'getAttributeFloat': getAttributeFloatAst,
-        'getAttributeVectorFloat': getAttributeVectorFloatAst
+        'getAttributeFloat': lambda call_node: cpp_ast.build_CPPCodeValue(get_attribute_float, call_node),
+        'getAttributeVectorFloat': lambda call_node: cpp_ast.build_CPPCodeValue(get_attribute_vector_float, call_node),
     }

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -827,9 +827,9 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         if type(value) is str:
             crep.set_rep(node, crep.cpp_value(f'"{value}"', self._gc.current_scope(), ctyp.terminal("string")))
         elif type(value) is int:
-            crep.set_rep(node, crep.cpp_value(value, self._gc.current_scope(), ctyp.terminal("int")))
+            crep.set_rep(node, crep.cpp_value(str(value), self._gc.current_scope(), ctyp.terminal("int")))
         elif type(value) is float:
-            crep.set_rep(node, crep.cpp_value(value, self._gc.current_scope(), ctyp.terminal("double")))
+            crep.set_rep(node, crep.cpp_value(str(value), self._gc.current_scope(), ctyp.terminal("double")))
         elif type(value) is bool:
             cpp_value = "true" if value else "false"
             crep.set_rep(node, crep.cpp_value(cpp_value, self._gc.current_scope(), ctyp.terminal('bool')))

--- a/func_adl_xAOD/common/executor.py
+++ b/func_adl_xAOD/common/executor.py
@@ -3,7 +3,7 @@
 import ast
 from func_adl_xAOD.common.event_collections import EventCollectionSpecification
 from typing import Any, Callable, Dict, List
-from func_adl_xAOD.common.meta_data import IncludeFileList, JobScriptSpecification, process_metadata
+from func_adl_xAOD.common.meta_data import InjectCodeBlock, JobScriptSpecification, process_metadata
 import os
 import sys
 from abc import ABC, abstractmethod
@@ -88,7 +88,7 @@ class executor(ABC):
         self._template_dir_name = template_dir_name
         self._method_names = method_names
         self._job_option_blocks = []
-        self._include_files: List[str] = []
+        self._inject_blocks: List[InjectCodeBlock] = []
 
     def _copy_template_file(self, j2_env, info, template_file, final_dir: Path):
         'Copy a file to a final directory'
@@ -118,8 +118,8 @@ class executor(ABC):
         })
         a = cpp_ast.cpp_ast_finder(method_names).visit(a)
 
-        # Pull out all include files required
-        self._include_files = list(itertools.chain(*[md.files for md in cpp_functions if isinstance(md, IncludeFileList)]))
+        # Save the injection blocks
+        self._inject_blocks = [md for md in cpp_functions if isinstance(md, InjectCodeBlock)]
 
         # Pull off any joboption blocks
         for m in cpp_functions:
@@ -129,10 +129,44 @@ class executor(ABC):
         # And return the modified ast
         return a
 
+    def _ib_fetch(self, name: str) -> List[str]:
+        'Return items from inject code blocks'
+        return list(itertools.chain(*[getattr(md, name) for md in self._inject_blocks]))
+
     @property
-    def include_files(self) -> List[str]:
-        'Return the list of include files from the query'
-        return self._include_files
+    def body_include_files(self) -> List[str]:
+        'Return the list of include files for the query.cpp file'
+        return self._ib_fetch('body_includes')
+
+    @property
+    def header_include_files(self) -> List[str]:
+        'Return the list of include files for the query.cpp file'
+        return self._ib_fetch('header_includes')
+
+    @property
+    def private_members(self) -> List[str]:
+        'Return the list of include files for the query.cpp file'
+        return self._ib_fetch('private_members')
+
+    @property
+    def instance_initialization(self) -> List[str]:
+        'Return the list of include files for the query.cpp file'
+        return self._ib_fetch('instance_initialization')
+
+    @property
+    def ctor_lines(self) -> List[str]:
+        'Return the list of include files for the query.cpp file'
+        return self._ib_fetch('ctor_lines')
+
+    @property
+    def link_libraries(self) -> List[str]:
+        'Return the list of include files for the query.cpp file'
+        return self._ib_fetch('link_libraries')
+
+    @property
+    def initialize_lines(self) -> List[str]:
+        'Return the list of include files for the query.cpp file'
+        return self._ib_fetch('initialize_lines')
 
     @abstractmethod
     def build_collection_callback(self, metadata: EventCollectionSpecification) -> Callable[[ast.Call], ast.Call]:
@@ -183,15 +217,20 @@ class executor(ABC):
         book_code = _cpp_source_emitter()
         qv.emit_book(book_code)
         class_decl_code = qv.class_declaration_code()
-        includes = qv.include_files() + self.include_files
-        link_libraries = qv.link_libraries()
+        includes = qv.include_files() + self.body_include_files
+        link_libraries = qv.link_libraries() + self.link_libraries
 
         # The replacement dict to pass to the template generator can now be filled
         info = {}
         info['query_code'] = query_code.lines_of_query_code()
         info['class_decl'] = class_decl_code
         info['book_code'] = book_code.lines_of_query_code()
-        info['include_files'] = includes
+        info['body_include_files'] = includes
+        info['header_include_files'] = self.header_include_files
+        info['private_members'] = self.private_members
+        info['instance_initialization'] = self.instance_initialization
+        info['initialize_lines'] = self.initialize_lines
+        info['ctor_lines'] = self.ctor_lines
         info['link_libraries'] = link_libraries
         info.update(self.add_to_replacement_dict())
 

--- a/func_adl_xAOD/common/executor.py
+++ b/func_adl_xAOD/common/executor.py
@@ -112,7 +112,7 @@ class executor(ABC):
         method_names = dict(self._method_names)
         method_names.update({
             md.name:
-                (lambda call_node: cpp_ast.build_CPPCodeValue(md, call_node)) if isinstance(md, cpp_ast.CPPCodeSpecification)  # type: ignore
+                (lambda call_node, md=md: cpp_ast.build_CPPCodeValue(md, call_node)) if isinstance(md, cpp_ast.CPPCodeSpecification)  # type: ignore
                 else self.build_collection_callback(md)
             for md in cpp_functions if isinstance(md, (cpp_ast.CPPCodeSpecification, EventCollectionSpecification))
         })

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -118,6 +118,9 @@ def process_metadata(md_list: List[Dict[str, Any]]) -> List[SpecificationTypes]:
                 md['code'],
                 md['result_name'] if 'result_name' in md else 'result',
                 md['return_type'],
+                bool(md['return_is_collection']) if 'return_is_collection' in md else False,
+                md['method_object'] if 'method_object' in md else None,
+                md['instance_object'] if 'instance_object' in md else None,
             )
             cpp_funcs.append(spec)
         elif md_type == 'add_atlas_event_collection_info':

--- a/func_adl_xAOD/template/atlas/r21/query.cxx
+++ b/func_adl_xAOD/template/atlas/r21/query.cxx
@@ -2,7 +2,7 @@
 #include <analysis/query.h>
 #include "xAODRootAccess/tools/TFileAccessTracer.h"
 
-{% for i in include_files %}
+{% for i in body_include_files %}
 #include "{{i}}"
 {% endfor %}
 
@@ -11,6 +11,9 @@
 query :: query (const std::string& name,
                                   ISvcLocator *pSvcLocator)
     : EL::AnaAlgorithm (name, pSvcLocator)
+  {% for l in instance_initialization %}
+  ,{{l}}
+  {%- endfor %}
 {
   // Here you put any code for the base initialization of variables,
   // e.g. initialize all pointers to 0.  This is also where you
@@ -23,6 +26,11 @@ query :: query (const std::string& name,
   // and for a large amount of data, this can sometimes take a minute.
   // So we get rid of it.
   xAOD::TFileAccessTracer::enableDataSubmission(false);
+
+  {% for l in ctor_lines %}
+  {{l}}
+  {% endfor %}
+
 }
 
 StatusCode query :: initialize ()
@@ -33,6 +41,10 @@ StatusCode query :: initialize ()
   // connected.
 
   {% for l in book_code %}
+  {{l}}
+  {% endfor %}
+
+  {% for l in initialize_lines %}
   {{l}}
   {% endfor %}
 

--- a/func_adl_xAOD/template/atlas/r21/query.h
+++ b/func_adl_xAOD/template/atlas/r21/query.h
@@ -3,6 +3,11 @@
 
 #include <AnaAlgorithm/AnaAlgorithm.h>
 
+{% for i in header_include_files %}
+#include "{{i}}"
+{% endfor %}
+
+
 class query : public EL::AnaAlgorithm
 {
 public:
@@ -21,6 +26,9 @@ private:
   {{l}}
   {% endfor %}
 
+  {% for l in private_members %}
+  {{l}}
+  {% endfor %}
 };
 
 #endif

--- a/tests/atlas/xaod/test_Jets.py
+++ b/tests/atlas/xaod/test_Jets.py
@@ -12,7 +12,7 @@ def test_get_attribute_float():
     # Check to see if there mention of push_back anywhere.
     lines = get_lines_of_code(r)
     print_lines(lines)
-    l_attribute = find_line_with("getAttribute", lines)
+    l_attribute = find_line_with("getAttribute<", lines)
     assert 'getAttribute<float>("emf")' in lines[l_attribute]
 
 
@@ -20,15 +20,6 @@ def test_get_attribute_float_wrong_args():
     with pytest.raises(Exception) as e:
         atlas_xaod_dataset() \
             .SelectMany('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: j.getAttributeFloat())') \
-            .value()
-
-    assert 'getAttribute' in str(e.value)
-
-
-def test_get_attribute_float_wrong_arg_type():
-    with pytest.raises(Exception) as e:
-        atlas_xaod_dataset() \
-            .SelectMany('lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: j.getAttributeFloat(1))') \
             .value()
 
     assert 'getAttribute' in str(e.value)
@@ -43,28 +34,8 @@ def test_get_attribute_vector_float():
     # Check to see if there mention of push_back anywhere.
     lines = get_lines_of_code(r)
     print_lines(lines)
-    l_attribute = find_line_with("getAttribute", lines)
+    l_attribute = find_line_with("getAttribute<", lines)
     assert 'getAttribute<std::vector<double>>("emf")' in lines[l_attribute]
-
-
-def test_get_attribute_vector_float_wrong_args():
-    with pytest.raises(Exception) as e:
-        atlas_xaod_dataset() \
-            .SelectMany('lambda e: e.Jets("AntiKt4EMTopoJets")') \
-            .SelectMany('lambda j: j.getAttributeVectorFloat("emf", 22)') \
-            .value()
-
-    assert 'getAttributeVectorFloat' in str(e.value)
-
-
-def test_get_attribute_vector_float_wrong_arg_type():
-    with pytest.raises(Exception) as e:
-        atlas_xaod_dataset() \
-            .SelectMany('lambda e: e.Jets("AntiKt4EMTopoJets")') \
-            .SelectMany('lambda j: j.getAttributeVectorFloat(1)') \
-            .value()
-
-    assert 'getAttributeVectorFloat' in str(e.value)
 
 
 def test_get_attribute():

--- a/tests/common/test_cpp_ast.py
+++ b/tests/common/test_cpp_ast.py
@@ -1,4 +1,8 @@
+import ast
+
 import pytest
+from func_adl_xAOD.common.cpp_ast import (CPPCodeSpecification, CPPCodeValue,
+                                          build_CPPCodeValue)
 from func_adl_xAOD.common.math_utils import DeltaR
 from tests.atlas.xaod.utils import atlas_xaod_dataset  # type: ignore
 
@@ -13,3 +17,87 @@ def test_deltaR_call():
 def test__bad_deltaR_call():
     with pytest.raises(ValueError):
         atlas_xaod_dataset().Select(lambda e: DeltaR(1.0, 1.0, 1.0)).value()  # type: ignore
+
+
+def test_build_cpp_cv_function():
+    'Test building and modifying a callback function'
+
+    func = CPPCodeSpecification(
+        name='my_func',
+        include_files=['my_include.h'],
+        arguments=['a', 'b'],
+        code=['auto result = a + b;'],
+        result='result',
+        cpp_return_type='double'
+    )
+
+    call_node = ast.parse('my_func(1, 2)').body[0].value  # type: ignore
+
+    r = build_CPPCodeValue(func, call_node)
+
+    assert isinstance(r.func, CPPCodeValue)
+    assert r.func.replacement_instance_obj is None
+
+
+def test_build_cpp_cv_function_bad_method():
+    'Test building and modifying a callback function'
+
+    func = CPPCodeSpecification(
+        name='my_func',
+        include_files=['my_include.h'],
+        arguments=['a', 'b'],
+        code=['auto result = a + b;'],
+        result='result',
+        cpp_return_type='double'
+    )
+
+    call_node = ast.parse('e.my_func(1, 2)').body[0].value  # type: ignore
+
+    with pytest.raises(ValueError) as e:
+        build_CPPCodeValue(func, call_node)
+
+    assert "method" in str(e.value)
+
+
+def test_build_cpp_cv_method():
+    'Test building and modifying a callback function'
+
+    func = CPPCodeSpecification(
+        name='my_func',
+        include_files=['my_include.h'],
+        arguments=['a', 'b'],
+        code=['auto result = a + b;'],
+        result='result',
+        cpp_return_type='double',
+        method_object='obj_j',
+        instance_object='xAOD::Jet_v1'
+    )
+
+    call_node = ast.parse('e.my_func(1, 2)').body[0].value  # type: ignore
+
+    r = build_CPPCodeValue(func, call_node)
+
+    assert isinstance(r.func, CPPCodeValue)
+    assert r.func.replacement_instance_obj is not None
+
+
+def test_build_cpp_cv_method_as_function():
+    'Test building and modifying a callback function'
+
+    func = CPPCodeSpecification(
+        name='my_func',
+        include_files=['my_include.h'],
+        arguments=['a', 'b'],
+        code=['auto result = a + b;'],
+        result='result',
+        cpp_return_type='double',
+        method_object='obj_j',
+        instance_object='xAOD::Jet_v1'
+    )
+
+    call_node = ast.parse('my_func(1, 2)').body[0].value  # type: ignore
+
+    with pytest.raises(ValueError) as e:
+        build_CPPCodeValue(func, call_node)
+
+    assert "function" in str(e)

--- a/tests/common/test_executor.py
+++ b/tests/common/test_executor.py
@@ -76,6 +76,35 @@ def test_metadata_cpp_code():
     assert isinstance(call_obj, CPPCodeValue)
 
 
+def test_metadata_cpp_code_capture():
+    'Make sure we do not capture bad data (bug seen)'
+
+    a1 = parse_statement('Select(MetaData(MetaData(ds, {'
+                         '"metadata_type": "add_job_script",'
+                         '"name": "apply_corrections",'
+                         '"script": ["line1"],'
+                         '"depends_on": [],'
+                         '}),{'
+                         '"metadata_type": "add_cpp_function",'
+                         '"name": "MyDeltaR",'
+                         '"include_files": ["TVector2.h", "math.h"],'
+                         '"arguments": ["eta1", "phi1", "eta2", "phi2"],'
+                         '"code": ['
+                         '   "auto d_eta = eta1 - eta2;",'
+                         '   "auto d_phi = TVector2::Phi_mpi_pi(phi1-phi2);",'
+                         '   "auto result = (d_eta*d_eta + d_phi*d_phi);"'
+                         '],'
+                         '"return_type": "double"'
+                         '}), lambda e: MyDeltaR(1,2,3,4))')
+
+    new_a1 = do_nothing_executor().apply_ast_transformations(a1)
+
+    assert 'CPPCodeValue' in ast.dump(new_a1)
+
+    call_obj = new_a1.args[1].body.func  # type: ignore
+    assert isinstance(call_obj, CPPCodeValue)
+
+
 def test_metadata_collection():
     'Make sure the metadata for a new collections goes all the way through'
 

--- a/tests/common/test_executor.py
+++ b/tests/common/test_executor.py
@@ -130,10 +130,12 @@ def test_include_files():
     'Make sure include files are properly dealt with'
 
     a1 = parse_statement('Select(MetaData(ds, {'
-                         '"metadata_type": "include_files",'
-                         '"files": ["xAODEventInfo/EventInfo.h"],'
+                         '"metadata_type": "inject_code",'
+                         '"body_includes": ["xAODEventInfo/EventInfo.h"],'
+                         '"header_includes": ["file.hpp"],'
                          '}), lambda e: e.crazy("fork").pT())')
 
     exe = do_nothing_executor()
     _ = exe.apply_ast_transformations(a1)
-    assert exe.include_files == ["xAODEventInfo/EventInfo.h"]
+    assert exe.body_include_files == ["xAODEventInfo/EventInfo.h"]
+    assert exe.header_include_files == ["file.hpp"]

--- a/tests/common/test_executor.py
+++ b/tests/common/test_executor.py
@@ -131,6 +131,7 @@ def test_include_files():
 
     a1 = parse_statement('Select(MetaData(ds, {'
                          '"metadata_type": "inject_code",'
+                         '"name": "crazy_fork",'
                          '"body_includes": ["xAODEventInfo/EventInfo.h"],'
                          '"header_includes": ["file.hpp"],'
                          '}), lambda e: e.crazy("fork").pT())')

--- a/tests/common/test_executor.py
+++ b/tests/common/test_executor.py
@@ -76,6 +76,56 @@ def test_metadata_cpp_code():
     assert isinstance(call_obj, CPPCodeValue)
 
 
+def test_metadata_cpp_code_unneeded():
+    'Make sure the metadata from a C++ bit of code is correctly put into type system'
+
+    a1 = parse_statement('Select(MetaData(ds, {'
+                         '"metadata_type": "add_cpp_function",'
+                         '"name": "MyDeltaR",'
+                         '"include_files": ["TVector2.h", "math.h"],'
+                         '"arguments": ["eta1", "phi1", "eta2", "phi2"],'
+                         '"code": ['
+                         '   "auto d_eta = eta1 - eta2;",'
+                         '   "auto d_phi = TVector2::Phi_mpi_pi(phi1-phi2);",'
+                         '   "auto result = (d_eta*d_eta + d_phi*d_phi);"'
+                         '],'
+                         '"return_type": "double"'
+                         '}), lambda e: MyDeltaRR(1,2,3,4))')
+
+    new_a1 = do_nothing_executor().apply_ast_transformations(a1)
+
+    assert 'CPPCodeValue' not in ast.dump(new_a1)
+
+    call_obj = new_a1.args[1].body.func  # type: ignore
+    assert isinstance(call_obj, ast.Name)
+
+
+def test_metadata_cpp_code_method():
+    'Run a method'
+
+    a1 = parse_statement('Select(MetaData(ds, {'
+                         '"metadata_type": "add_cpp_function",'
+                         '"name": "MyDeltaR",'
+                         '"include_files": ["TVector2.h", "math.h"],'
+                         '"arguments": ["eta1", "phi1", "eta2", "phi2"],'
+                         '"code": ['
+                         '   "auto d_eta = eta1 - eta2;",'
+                         '   "auto d_phi = TVector2::Phi_mpi_pi(phi1-phi2);",'
+                         '   "auto result = (d_eta*d_eta + d_phi*d_phi);"'
+                         '],'
+                         '"method_object": "obj_j",'
+                         '"instance_object": "xAOD::Jet_v1",'
+                         '"return_type": "double",'
+                         '}), lambda e: e.MyDeltaR(1,2,3,4))')
+
+    new_a1 = do_nothing_executor().apply_ast_transformations(a1)
+
+    assert 'CPPCodeValue' in ast.dump(new_a1)
+
+    call_obj = new_a1.args[1].body.func  # type: ignore
+    assert isinstance(call_obj, CPPCodeValue)
+
+
 def test_metadata_cpp_code_capture():
     'Make sure we do not capture bad data (bug seen)'
 

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -222,6 +222,7 @@ def test_md_code_block():
     metadata = [
         {
             'metadata_type': 'inject_code',
+            'name': "my_code_block",
             'body_includes': ['file1.h', 'file2.h'],
             'header_includes': ['file3.h', 'file4.h'],
             'private_members': ['int first;'],
@@ -259,6 +260,7 @@ def test_md_code_block_one_at_a_time():
         metadata = [
             {
                 'metadata_type': 'inject_code',
+                'name': "my_code_block",
                 k: md[k],
             }
         ]
@@ -293,6 +295,47 @@ def test_md_code_block_empty():
     ]
     r = process_metadata(metadata)
     assert len(r) == 0
+
+
+def test_md_code_block_duplicate():
+    'make sure all options of a code block work'
+    block1 = {
+        'metadata_type': 'inject_code',
+        'name': "my_code_block",
+        'body_includes': ['file1.h', 'file2.h'],
+        'header_includes': ['file3.h', 'file4.h'],
+        'private_members': ['int first;'],
+        'instance_initialization': ['first(10)'],
+        'ctor_lines': ['first = first * 10;'],
+        'initialize_lines': ['line1', 'line2'],
+        'link_libraries': ['lib1', 'lib2'],
+    }
+    metadata = [block1, dict(block1)]
+    r = process_metadata(metadata)
+    assert len(r) == 1
+
+
+def test_md_code_block_duplicate_bad():
+    'make sure all options of a code block work'
+    block1 = {
+        'metadata_type': 'inject_code',
+        'name': "my_code_block",
+        'body_includes': ['file1.h', 'file2.h'],
+        'header_includes': ['file3.h', 'file4.h'],
+        'private_members': ['int first;'],
+        'instance_initialization': ['first(10)'],
+        'ctor_lines': ['first = first * 10;'],
+        'initialize_lines': ['line1', 'line2'],
+        'link_libraries': ['lib1', 'lib2'],
+    }
+    block2 = dict(block1)
+    block2['body_includes'] = ['file5.h']
+    metadata = [block1, block2]
+
+    with pytest.raises(ValueError) as e:
+        process_metadata(metadata)
+
+    assert 'my_code_block' in str(e)
 
 
 def test_md_atlas_collection():

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -16,7 +16,7 @@ from func_adl_xAOD.common.event_collections import (
     EventCollectionSpecification, event_collection_coder,
     event_collection_container)
 from func_adl_xAOD.common.executor import executor
-from func_adl_xAOD.common.meta_data import (IncludeFileList,
+from func_adl_xAOD.common.meta_data import (InjectCodeBlock,
                                             JobScriptSpecification,
                                             generate_script_block,
                                             process_metadata)
@@ -217,12 +217,18 @@ def test_with_method_call_with_type(caplog):
     assert 'pT' not in caplog.text
 
 
-def test_md_include_files():
-    'Add some include files'
+def test_md_code_block():
+    'make sure all options of a code block work'
     metadata = [
         {
-            'metadata_type': 'include_files',
-            'files': ['file1.h', 'file2.h'],
+            'metadata_type': 'inject_code',
+            'body_includes': ['file1.h', 'file2.h'],
+            'header_includes': ['file3.h', 'file4.h'],
+            'private_members': ['int first;'],
+            'instance_initialization': ['first(10)'],
+            'ctor_lines': ['first = first * 10;'],
+            'initialize_lines': ['line1', 'line2'],
+            'link_libraries': ['lib1', 'lib2'],
         }
     ]
 
@@ -230,8 +236,63 @@ def test_md_include_files():
 
     assert len(result) == 1
     s = result[0]
-    assert isinstance(s, IncludeFileList)
-    assert s.files == ['file1.h', 'file2.h']
+    assert isinstance(s, InjectCodeBlock)
+    assert s.body_includes == ['file1.h', 'file2.h']
+    assert s.header_includes == ['file3.h', 'file4.h']
+    assert s.private_members == ['int first;']
+    assert s.instance_initialization == ['first(10)']
+    assert s.ctor_lines == ['first = first * 10;']
+    assert s.link_libraries == ['lib1', 'lib2']
+    assert s.initialize_lines == ['line1', 'line2']
+
+
+def test_md_code_block_one_at_a_time():
+    md = {
+        'body_includes': ['file1.h', 'file2.h'],
+        'header_includes': ['file3.h', 'file4.h'],
+        'private_members': ['int first;'],
+        'instance_initialization': ['first(10)'],
+        'ctor_lines': ['first = first * 10;'],
+        'link_libraries': ['lib1', 'lib2'],
+    }
+    for k in md.keys():
+        metadata = [
+            {
+                'metadata_type': 'inject_code',
+                k: md[k],
+            }
+        ]
+
+        process_metadata(metadata)
+
+
+def test_md_code_block_bad_item():
+    metadata = [
+        {
+            'metadata_type': 'inject_code',
+            'body_includes': ['file1.h', 'file2.h'],
+            'header_includes': ['file3.h', 'file4.h'],
+            'private_members': ['int first;'],
+            'instance_initialization': ['first(10)'],
+            'ctor_lines': ['first = first * 10;'],
+            'link_libraries_f': ['lib1', 'lib2'],
+        }
+    ]
+
+    with pytest.raises(ValueError) as e:
+        process_metadata(metadata)
+
+    assert "link_libraries_f" in str(e)
+
+
+def test_md_code_block_empty():
+    metadata = [
+        {
+            'metadata_type': 'inject_code',
+        }
+    ]
+    r = process_metadata(metadata)
+    assert len(r) == 0
 
 
 def test_md_atlas_collection():

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -543,6 +543,32 @@ def test_md_function_call():
     assert spec.cpp_return_type == 'double'
 
 
+def test_md_method_call():
+    'Inject code to run some C++ as a method'
+    metadata = [
+        {
+            'metadata_type': 'add_cpp_function',
+            'name': 'getAttributeFloat',
+            'include_files': [],
+            'arguments': ['name'],
+            'instance_object': 'obj_j',
+            'method_object': 'xAOD::Jet_v1',
+            'code': [
+                'auto result = obj_j->getAttribute<float>(name);'
+            ],
+            'return_type': 'double'
+        }
+    ]
+
+    specs = process_metadata(metadata)
+    assert len(specs) == 1
+    spec = specs[0]
+    assert isinstance(spec, CPPCodeSpecification)
+
+    assert spec.method_object == 'xAOD::Jet_v1'
+    assert spec.instance_object == 'obj_j'
+
+
 def test_md_function_call_renamed_result():
     'Check result name is properly set'
     metadata = [


### PR DESCRIPTION
Contains the following:

* Fixes a metadata capture bug that meant C++ functions were hidden by other forms of metadata in the request
* Added `inject_code` metadata block - it will allow you to insert code in all sorts of places. Implemented fro ATLAS only right now.
* the cpp function injection can now also work for methods