### PR TITLE
Mount a docker volume as cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,3 +239,5 @@ logging.getLogger("func_adl_xAOD.common.local_dataset").setLevel(level=logging.D
 ```
 
 - In general, the first two lines are a good thing to have in your notebooks, etc. It allows you to see where warning messages are coming from and might help when things are going sideways.
+
+Note that some of the local runners will use a docker volume to cache calibration files and the like. If you need a truly fresh start, you'll need to remove the volume first.

--- a/func_adl_xAOD/atlas/xaod/local_dataset.py
+++ b/func_adl_xAOD/atlas/xaod/local_dataset.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import List, Optional, Union
 
-from func_adl_xAOD.common.local_dataset import LocalDataset
+from func_adl_xAOD.common.local_dataset import LocalDataset, docker_volume_info
 from func_adl_xAOD.atlas.xaod.executor import atlas_xaod_executor
 from func_adl_xAOD.common.executor import executor
 
@@ -34,3 +34,6 @@ class xAODDataset(LocalDataset):
             executor: Return the executor
         '''
         return atlas_xaod_executor()
+
+    def docker_cache_volume(self) -> List[docker_volume_info]:
+        return [docker_volume_info(docker_name='atlas_xaod_calibration_cache', mount_point='/xaod_calibration_cache')]

--- a/func_adl_xAOD/cms/aod/local_dataset.py
+++ b/func_adl_xAOD/cms/aod/local_dataset.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import List, Optional, Union
 
-from func_adl_xAOD.common.local_dataset import LocalDataset
+from func_adl_xAOD.common.local_dataset import LocalDataset, docker_volume_info
 from func_adl_xAOD.cms.aod.executor import cms_aod_executor
 from func_adl_xAOD.common.executor import executor
 
@@ -31,3 +31,6 @@ class CMSRun1AODDataset(LocalDataset):
             executor: Return the executor
         '''
         return cms_aod_executor()
+
+    def docker_cache_volume(self) -> List[docker_volume_info]:
+        return []

--- a/func_adl_xAOD/template/atlas/r21/runner.sh
+++ b/func_adl_xAOD/template/atlas/r21/runner.sh
@@ -14,6 +14,7 @@ input_method="filelist"
 input_file=""
 compile=1
 run=1
+calib_cache="/xaod_calibration_cache"
 
 while getopts "d:o:cr" opt; do
     case "$opt" in
@@ -182,6 +183,16 @@ if [ $run = 1 ]; then
    if [ -e ./bogus ]; then
      rm -rf bogus
    fi
+
+   # If there is a calibration path, lets try to use it.
+   if [ -e $calib_cache ]; then
+      export CALIBPATH=$calib_cache:$CALIBPATH
+      sudo -i chmod a+w $calib_cache
+      echo "Using calibration cache: $calib_cache"
+      echo "Update calibration sources: $CALIBPATH"
+   fi
+
+   # Finally, run!
    python ../source/analysis/share/ATestRun_eljob.py --submission-dir=bogus
 
    # Place the output file where it belongs


### PR DESCRIPTION
* Any local executor can specify a list of docker volumnes to mount
* ATLAS does one for calibration constant files

This makes a significant improvement in speed (5:45 down to under 2 minutes).