### PR TITLE
fix: Remove deleted codecov Python package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
             "pytest-cov",
             "coverage",
             "flake8",
-            "codecov",
             "autopep8",
             "twine",
             "testfixtures",


### PR DESCRIPTION
* On 2023-04-12 Codecov deleted the codecov package from PyPI. As the package no longer exists any attempt to install the 'test' extra dependencies will fail.
   - c.f. https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259