### PR TITLE
CI/Tests failing 

### DIFF
--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -697,7 +697,6 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
                 crep.set_rep(call_node, r)
 
     def visit_Attribute(self, node: ast.Attribute) -> Any:
-
         obj = self.get_rep(node.value)
         variable = node.attr
         if not isinstance(obj, crep.cpp_value):
@@ -790,7 +789,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
             node (ast.BinOp): The binary node to process
 
         """
-        if type(node.op) == ast.Pow:
+        if type(node.op) is ast.Pow:
             left = cast(crep.cpp_value, self.get_rep(node.left))
             right = cast(crep.cpp_value, self.get_rep(node.right))
             best_type = ctyp.terminal("double", False)
@@ -888,7 +887,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         right = cast(crep.cpp_value, self.get_rep(node.comparators[0]))
 
         r = crep.cpp_value(
-            f"({left.as_cpp()}{compare_operations[type(node.ops[0])]}{right.as_cpp()})",
+            f"({left.as_cpp()}{compare_operations[type(node.ops[0])]}{right.as_cpp()})",  # type: ignore
             self._gc.current_scope(),
             ctyp.terminal("bool"),
         )
@@ -910,7 +909,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
 
         # How we check and short-circuit depends on if we are doing and or or.
         check_expr = (
-            result.as_cpp() if type(node.op) == ast.And else f"!{result.as_cpp()}"
+            result.as_cpp() if type(node.op) is ast.And else f"!{result.as_cpp()}"
         )
         check = crep.cpp_value(
             check_expr, self._gc.current_scope(), cpp_type=ctyp.terminal("bool")

--- a/tests/atlas/xaod/test_integrated_query.py
+++ b/tests/atlas/xaod/test_integrated_query.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 from func_adl_xAOD.common.math_utils import DeltaR  # NOQA
-from testfixtures import LogCapture
+from testfixtures import LogCapture  # type: ignore
 from tests.atlas.xaod.config import f_single, run_long_running_tests
 from tests.atlas.xaod.utils import as_awkward, as_pandas, as_pandas_async
 

--- a/tests/atlas/xaod/test_integrated_query.py
+++ b/tests/atlas/xaod/test_integrated_query.py
@@ -169,9 +169,11 @@ def test_md_job_options():
 def test_event_info_includes():
     "Make sure event info is pulling in the correct includes"
     training_df = as_pandas(
-        f_single.Select(lambda e: e.EventInfo("EventInfo")).Select(
-            lambda e: e.runNumber()
-        )
+        # fmt: off
+        f_single
+        .Select(lambda e: e.EventInfo("EventInfo"))
+        .Select(lambda e: e.runNumber())
+        # fmt: on
     )
     print(training_df)
     assert len(training_df) == 10

--- a/tests/cms/miniaod/test_integrated_query.py
+++ b/tests/cms/miniaod/test_integrated_query.py
@@ -24,7 +24,11 @@ def turn_on_logging():
 
 def test_select_pt_of_muons():
     training_df = as_pandas(
-        f_single.SelectMany(lambda e: e.Muons("slimmedMuons")).Select(lambda m: m.pt())
+        # fmt: off
+        f_single
+        .SelectMany(lambda e: e.Muons("slimmedMuons"))
+        .Select(lambda m: m.pt())
+        # fmt: on
     )
 
     assert training_df.iloc[0]["col1"] == 12.901309967041016
@@ -34,9 +38,11 @@ def test_select_pt_of_muons():
 
 def test_select_pt_of_electrons():
     training_df = as_pandas(
-        f_single.SelectMany(lambda e: e.Electrons("slimmedElectrons")).Select(
-            lambda m: m.pt()
-        )
+        # fmt: off
+        f_single
+        .SelectMany(lambda e: e.Electrons("slimmedElectrons"))
+        .Select(lambda m: m.pt())
+        # fmt: on
     )
 
     assert training_df.iloc[0]["col1"] == 4.862127780914307
@@ -46,9 +52,11 @@ def test_select_pt_of_electrons():
 
 def test_select_twice_pt_of_global_muons():
     training_df = as_pandas(
-        f_single.SelectMany(lambda e: e.Muons("slimmedMuons")).Select(
-            lambda m: m.pt() * 2
-        )
+        # fmt: off
+        f_single
+        .SelectMany(lambda e: e.Muons("slimmedMuons"))
+        .Select(lambda m: m.pt() * 2)
+        # fmt: on
     )
 
     assert training_df.iloc[0]["col1"] == 25.80261993408203
@@ -58,7 +66,11 @@ def test_select_twice_pt_of_global_muons():
 
 def test_select_eta_of_global_muons():
     training_df = as_pandas(
-        f_single.SelectMany(lambda e: e.Muons("slimmedMuons")).Select(lambda m: m.eta())
+        # fmt: off
+        f_single
+        .SelectMany(lambda e: e.Muons("slimmedMuons"))
+        .Select(lambda m: m.eta())
+        # fmt: on
     )
 
     assert training_df.iloc[0]["col1"] == -1.2982407808303833
@@ -68,9 +80,11 @@ def test_select_eta_of_global_muons():
 
 def test_select_pt_eta_of_global_muons():
     training_df = as_pandas(
-        f_single.SelectMany(lambda e: e.Muons("slimmedMuons")).Select(
-            lambda m: m.pt() + m.eta()
-        )
+        # fmt: off
+        f_single
+        .SelectMany(lambda e: e.Muons("slimmedMuons"))
+        .Select(lambda m: m.pt() + m.eta())
+        # fmt: on
     )
 
     assert training_df.iloc[0]["col1"] == 11.603069186210632
@@ -87,9 +101,10 @@ def test_select_hitpattern_of_global_muons():
             .Select(lambda m: m.globalTrack())
             .Select(lambda m: m.hitPattern())
             .Select(
-                lambda hp: Range(0, hp.numberOfHits(hp.TRACK_HITS)).Select(
-                    lambda i: hp.getHitPattern(hp.TRACK_HITS, i)
-                )
+                # fmt: off
+                lambda hp: Range(0, hp.numberOfHits(hp.TRACK_HITS))
+                .Select(lambda i: hp.getHitPattern(hp.TRACK_HITS, i))
+                # fmt: on
             )
         )
     )
@@ -113,9 +128,11 @@ def test_isnonull_call():
 
 def test_sumChargedHadronPt():
     training_df = as_pandas(
-        f_single.SelectMany(lambda e: e.Muons("slimmedMuons")).Select(
-            lambda m: (m.pfIsolationR04()).sumChargedHadronPt
-        )
+        # fmt: off
+        f_single
+        .SelectMany(lambda e: e.Muons("slimmedMuons"))
+        .Select(lambda m: (m.pfIsolationR04()).sumChargedHadronPt)
+        # fmt: on
     )
     assert training_df.iloc[0]["col1"] == 0.0
     assert training_df.iloc[2]["col1"] == 26.135541915893555


### PR DESCRIPTION
They just started failing quietly a few months ago. This PR will get everything working again.

* Fixed issues where `black` had reformatted code so that we couldn't tell where one method started and the other ended.
* Modern version of `flake8` is catching more errors now.
* The python 3.7 on macOS failure may have been suprious - it seems to work currently on the CI infrastructure.

Fixes #214