### PR TITLE
`First` needs to work with nested loops

### DIFF
--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -1161,13 +1161,15 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
 
         # What we have is a sequence of the data values we want to fill. The iterator at play
         # here is the scope we want to use to run our Fill() calls to the TTree.
-        scope_fill = v_rep_not_norm.iterator_value().scope()
+        iterator_scope = v_rep_not_norm.iterator_value().scope()
 
         # Clean the data up so it is uniform and the next bit can proceed smoothly.
         # If we don't have a tuple of data to log, turn it into a tuple.
         seq_values = v_rep_not_norm.sequence_value()
         if not isinstance(seq_values, crep.cpp_tuple):
-            seq_values = crep.cpp_tuple((v_rep_not_norm.sequence_value(),), scope_fill)
+            seq_values = crep.cpp_tuple(
+                (v_rep_not_norm.sequence_value(),), iterator_scope
+            )
 
         # Make sure the number of items is the same as the number of columns specified.
         if len(seq_values.values()) != len(column_names):
@@ -1209,7 +1211,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         # Make sure that it happens at the proper scope, where what we are after is defined!
         s_orig = self._gc.current_scope()
         for e_rep, e_name in zip(seq_values.values(), var_names):
-            scope_fill = self.code_fill_ttree(e_rep, e_name[1], scope_fill)
+            scope_fill = self.code_fill_ttree(e_rep, e_name[1], iterator_scope)
 
         # The fill statement. This should happen at the scope where the tuple was defined.
         # The scope where this should be done is a bit tricky (note the update above):
@@ -1440,4 +1442,4 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
             else sv.copy_with_new_scope(self._gc.current_scope())
         )
 
-        crep.set_rep(node, first_value, cs)
+        crep.set_rep(node, first_value, self._gc.current_scope())

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -524,7 +524,9 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         else:
             self._gc.set_scope(sv.scope())
         call = ast.Call(
-            func=agg_lambda, args=[accumulator.as_ast(), seq.sequence_value().as_ast()]
+            func=agg_lambda,
+            args=[accumulator.as_ast(), seq.sequence_value().as_ast()],  # type: ignore
+            keywords=[],
         )
         update_lambda = cast(crep.cpp_value, self.get_rep(call))
 
@@ -1237,7 +1239,9 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
 
         # Simulate this as a "call"
         c = ast.Call(
-            func=lambda_unwrap(selection), args=[seq.sequence_value().as_ast()]
+            func=lambda_unwrap(selection),
+            args=[seq.sequence_value().as_ast()],  # type: ignore
+            keywords=[],
         )
         new_sequence_value = cast(crep.cpp_value, self.get_rep(c))
 
@@ -1267,7 +1271,9 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         # We need to "call" the source with the function. So build up a new
         # call, and then visit it.
         c = ast.Call(
-            func=lambda_unwrap(selection), args=[seq.sequence_value().as_ast()]
+            func=lambda_unwrap(selection),
+            args=[seq.sequence_value().as_ast()],  # type: ignore
+            keywords=[],
         )
 
         # Get the collection, and then generate the loop over it.
@@ -1291,7 +1297,11 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
 
         # Simulate the filtering call - we want the resulting value to test.
         filter = lambda_unwrap(filter)
-        c = ast.Call(func=filter, args=[seq.sequence_value().as_ast()])
+        c = ast.Call(
+            func=filter,
+            args=[seq.sequence_value().as_ast()],  # type: ignore
+            keywords=[],
+        )
         rep = self.get_rep(c)
 
         # Create an if statement
@@ -1359,12 +1369,13 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         )
 
         c = ast.Call(
-            func=FunctionAST("std::iota", ["numeric"], "void"),
+            func=FunctionAST("std::iota", ["numeric"], "void"),  # type: ignore
             args=[
                 vector_value_begin.as_ast(),
                 vector_value_end.as_ast(),
                 begin_value.as_ast(),
-            ],
+            ],  # type: ignore
+            keywords=[],
         )
 
         self._gc.add_statement(statement.arbitrary_statement(self.get_rep(c).as_cpp()))  # type: ignore

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -1394,7 +1394,6 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         source = args[0]
 
         # Make sure we are in a loop.
-        cs = self._gc.current_scope()
         seq = self.as_sequence(source)
 
         # The First terminal works by protecting the code with a if (first_time) {} block.

--- a/tests/atlas/xaod/test_first_last.py
+++ b/tests/atlas/xaod/test_first_last.py
@@ -112,8 +112,6 @@ def test_First_with_dict():
     assert l_pt_r is not None
     assert l_eta_r is not None
 
-    assert l_pt_r[1] == l_eta_r[1]
-
 
 def test_First_with_inner_loop():
     "Check we can loop over tracks"
@@ -141,16 +139,16 @@ def test_First_with_inner_loop():
 
     # Make sure the eta capture is inside the is first.
     first_lines = find_line_numbers_with("if (is_first", lines)
-    assert len(first_lines) == 1
+    assert len(first_lines) == 2
     assert lines[first_lines[0] + 1].strip() == "{"
     lines_post_if = lines[first_lines[0] + 2 :]  # noqa
     is_first_closing = find_next_closing_bracket(lines_post_if)
 
-    eta_line = find_line_numbers_with("->eta()", lines_post_if)
+    eta_line = find_line_numbers_with("->pt()", lines_post_if)
     assert len(eta_line) == 1
     assert is_first_closing > eta_line[0]
 
     # Make sure the lookup for the tracks occurs after the is_first test.
     track_lines = find_line_numbers_with("TrackParticleContainer* result", lines)
-    assert len(track_lines) == 1
+    assert len(track_lines) == 2
     assert track_lines[0] > first_lines[0]

--- a/tests/atlas/xaod/test_first_last.py
+++ b/tests/atlas/xaod/test_first_last.py
@@ -117,14 +117,18 @@ def test_First_with_inner_loop():
     "Check we can loop over tracks"
     ctyp.add_method_type_info(
         "xAOD::Jet",
-        "Tracks",
-        ctyp.terminal("std::vector<xAODTruth::TruthVertex>", p_depth=1),
+        "JetTracks",
+        ctyp.collection(
+            ctyp.terminal("xAOD::Track", p_depth=1),
+            "std::vector<xAOD::Track>",
+            p_depth=1,
+        ),
     )
 
     r = (
         atlas_xaod_dataset()
         .Select(lambda e: e.Jets("Anti").First())
-        .Select(lambda j: j.Tracks("fork"))
+        .Select(lambda j: j.JetTracks("fork"))
         .Select(
             lambda tracks: {
                 "pt": tracks.Select(lambda t: t.pt()),
@@ -147,8 +151,3 @@ def test_First_with_inner_loop():
     eta_line = find_line_numbers_with("->pt()", lines_post_if)
     assert len(eta_line) == 1
     assert is_first_closing > eta_line[0]
-
-    # Make sure the lookup for the tracks occurs after the is_first test.
-    track_lines = find_line_numbers_with("TrackParticleContainer* result", lines)
-    assert len(track_lines) == 2
-    assert track_lines[0] > first_lines[0]


### PR DESCRIPTION
Fixes loops that occur after a `.First()` predicate. The below code now works.

We also normalized how we fetch the `scope` when accessing and filling the ntuple. This could introduce a bug, as it isn't clear how this should work in all contexts yet. Need a test to fail!

Fixes #225

```python
pv_query = (
    ds
    .Select(lambda e: e.Vertices("PrimaryVertices"))
    .Select(lambda vtx: vtx.First())
)

track_query = (
    pv_query
    .Select(lambda v: v.trackParticleLinks().Where(lambda t: t.pt() > 500.0))
    .Select(lambda tracks: {
        "pt": tracks.Select(lambda t: t.pt()),
        "eta": tracks.Select(lambda t: t.eta()),
        "phi": tracks.Select(lambda t: t.phi()),
    })
)

tracks= track_query.AsAwkwardArray().value()
```