### PR TITLE
feat: Add error handling for empty sequence in First() method

### DIFF
--- a/tests/atlas/xaod/test_first_last.py
+++ b/tests/atlas/xaod/test_first_last.py
@@ -162,7 +162,7 @@ def test_First_with_inner_loop():
 
     # Make sure the eta capture is inside the is first.
     first_lines = find_line_numbers_with("if (is_first", lines)
-    assert len(first_lines) == 2
+    assert len(first_lines) == 4
     assert lines[first_lines[0] + 1].strip() == "{"
     lines_post_if = lines[first_lines[0] + 2 :]  # noqa
     is_first_closing = find_next_closing_bracket(lines_post_if)

--- a/tests/atlas/xaod/test_first_last.py
+++ b/tests/atlas/xaod/test_first_last.py
@@ -26,6 +26,25 @@ def test_first_after_SelectMany():
     print_lines(lines)
 
 
+def test_first_failure():
+    r = (
+        atlas_xaod_dataset()
+        .Select(lambda e: e.Jets("bogus").Select(lambda j: j.pt()).First())
+        .value()
+    )
+
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+
+    fail_line = find_line_numbers_with("if (is_first", lines)
+    assert len(fail_line) == 2
+
+    lines_after_fail = lines[fail_line[1] :]  # noqa
+    i = find_next_closing_bracket(lines_after_fail)
+    remaining_lines = lines_after_fail[i + 1 :]  # noqa
+    assert len(remaining_lines) == 0
+
+
 def test_first_after_where():
     # Part of testing that First puts its outer settings in the right place.
     # This also tests First on a collection of objects that hasn't been pulled a part

--- a/tests/atlas/xaod/test_integrated_query.py
+++ b/tests/atlas/xaod/test_integrated_query.py
@@ -237,6 +237,24 @@ def test_first_object_in_event():
     assert int(training_df.iloc[0]["col1"]) == 52  # type: ignore
 
 
+def test_no_first_object_in_event(caplog):
+    "Make sure a failed first properly blows its stack"
+    try:
+        as_pandas(
+            f_single.Select(
+                lambda e: e.Jets("AntiKt4EMTopoJets")
+                .Where(lambda j: j.pt() > 1000000000.0)
+                .First()
+                .pt()
+                / 1000.0
+            )
+        )
+    except Exception as e:
+        assert "docker" in str(e)
+
+    assert "caught exception: First() called on an empty sequence" in caplog.text
+
+
 def test_no_reported_statistics():
     "Look at the log file and report if it contains a statistics line"
 

--- a/tests/atlas/xaod/test_xaod_aggragate.py
+++ b/tests/atlas/xaod/test_xaod_aggragate.py
@@ -289,7 +289,7 @@ def test_sequence_with_where_first():
     lines = get_lines_of_code(r)
     print_lines(lines)
     l_first = find_line_numbers_with("if (is_first", lines)
-    assert 1 == len(l_first)
+    assert 2 == len(l_first)
     active_blocks = find_open_blocks(lines[: l_first[0]])
     assert 1 == ["for" in a for a in active_blocks].count(True)
     l_agg = find_line_with("+1", lines)


### PR DESCRIPTION
* Add check to make sure all `First()` calls check to make sure something was found.
* Raise an exception with some bad error message when it happens.

Fixes #227