### PR TITLE
Add protection around the call to release setup

### DIFF
--- a/func_adl_xAOD/template/atlas/r21/runner.sh
+++ b/func_adl_xAOD/template/atlas/r21/runner.sh
@@ -44,7 +44,11 @@ if [ $# != 0 ]; then
 fi
 
 # Setup and config
-source /home/atlas/release_setup.sh
+if [ -f /home/atlas/release_setup.sh ]; then
+   source /home/atlas/release_setup.sh
+else
+   echo "/home/atlas/release_setup.sh not found. Skipping."
+fi
 
 # Remember where we are and the script location.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/tests/atlas/xaod/test_integrated_query.py
+++ b/tests/atlas/xaod/test_integrated_query.py
@@ -167,7 +167,7 @@ def test_md_job_options():
 
 
 def test_event_info_includes():
-    "Make sure event info is pulling in the correct includes"
+    "Make sure event info is pulling in the correct include files"
     training_df = as_pandas(
         # fmt: off
         f_single


### PR DESCRIPTION
Runner.sh shouldn't rely on /home/atlas being present 
Fixes #234