### PR TITLE
Add tests around constant values

### DIFF
--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -186,6 +186,20 @@ def test_ifexpr():
     assert "if " in lines[0]
 
 
+def test_constant():
+    r = (
+        atlas_xaod_dataset(qastle_roundtrip=True)
+        .Select(lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: 1.0))
+        .value()
+    )
+    # Make sure that a test around 10.0 occurs.
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+    push_line = [index for index, line in enumerate(lines) if "push_back(1.0)" in line]
+    assert len(push_line) == 1
+    assert lines[push_line[0] + 1].strip() == "}"
+
+
 def test_per_jet_item_with_where():
     # The following statement should be a straight sequence, not an array.
     r = (

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -301,6 +301,27 @@ def test_dict_simple_reference_prop_lookup():
     assert r == -1
 
 
+def test_dict_code_not_used_not_generated():
+    "Dictionary references should be resolved automatically"
+    r = (
+        atlas_xaod_dataset()
+        .Select(
+            lambda e: {
+                "e_list": e.Electrons("Electrons"),
+                "m_list": e.Muons("Muons").First().pt() + 33,
+            }
+        )
+        .Select(lambda e: e["e_list"].Select(lambda e: e.E()))
+        .value()
+    )
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+    l_push = find_line_with("push_back", lines)
+    assert "->E()" in lines[l_push]
+    r = find_line_with("muon", lines, throw_if_not_found=False)
+    assert r == -1
+
+
 def test_dict_ref_twice():
     "Dictionary references should be ok with being referenced twice"
     r = (

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -322,52 +322,6 @@ def test_dict_code_not_used_not_generated():
     assert r == -1
 
 
-def test_dict_ref_twice():
-    "Dictionary references should be ok with being referenced twice"
-    r = (
-        atlas_xaod_dataset()
-        .Select(lambda e: {"e_list": e.Electrons("Electrons")})
-        .Select(
-            lambda e: {
-                "E": e["e_list"].Select(lambda e: e.E()),
-                "pt": e["e_list"].Select(lambda e: e.pt()),
-            }
-        )
-        .value()
-    )
-    lines = get_lines_of_code(r)
-    print_lines(lines)
-    l_push = find_line_numbers_with("electrons", lines)
-    assert len([ln for ln in l_push if "for (auto" in lines[ln]]) == 2
-
-
-def test_dict_ref_confusion():
-    """Found in the wild. The dictionary reference is copied by
-    reference, which results in type resolution happening once - since
-    it is attached to the ast object, and it is... used twice.
-    """
-    r = (
-        atlas_xaod_dataset()
-        .Select(lambda e: {"e_list": e.Electrons("Electrons"), "raw": e})
-        .Select(
-            lambda e: {"e_list": e["e_list"], "e": e["e_list"].First(), "raw": e["raw"]}
-        )
-        .Select(
-            lambda e: {
-                "E_list": [e["e"].E() for _ in e["e_list"]],
-                # "E_list": [
-                #     e["raw"].Electrons("Electrons").First().E() for _ in e["e_list"]
-                # ],
-            }
-        )
-        .value()
-    )
-    lines = get_lines_of_code(r)
-    print_lines(lines)
-    l_push = find_line_numbers_with("for (auto", lines)
-    assert len(l_push) == 2
-
-
 def test_result_awkward():
     # The following statement should be a straight sequence, not an array.
     r = (

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -337,7 +337,7 @@ def test_dict_ref_twice():
     )
     lines = get_lines_of_code(r)
     print_lines(lines)
-    l_push = find_line_numbers_with("electrons0", lines)
+    l_push = find_line_numbers_with("electrons", lines)
     assert len([ln for ln in l_push if "for (auto" in lines[ln]]) == 2
 
 


### PR DESCRIPTION
* Added two tests around constant values (e.g. `.Select(lambda j: 1)`) to make sure they are properly rendered.
* Added a test to make sure complex dictionary values that aren't referenced are never emitted in C++ code.

Note that this work was in connection to tracking down the below bug. It turns out the [fix for that bug is actually in `func_adl`](https://github.com/iris-hep/func_adl/pull/184)

Fixes #239