### PR TITLE
Injected C++ functions can return pointers to objects

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,9 @@ jobs:
           pip install git+https://github.com/iris-hep/ast-language.git@e6470deb68529e1885a4bc46f781e2fe43a6f4c8
           pip install --no-cache-dir -e .[test,local]
           pip list
+      - name: Install Docker on macOS
+        if: matrix.platform == 'macOS-latest'
+        run: brew install docker
       - name: Test with pytest
         run: |
           python -m pytest -m "not atlas_xaod_runner and not atlas_r22_xaod_runner and not cms_aod_runner and not cms_miniaod_runner"

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ the optional parameter `instance_obj` should be specified.
 | instance_object | Present only if this is an object replacement. It species the code string that should be replaced by the current object | `"xAOD::Jet_vt"` |
 | method_object | The object name that the method can be called on. Present only if this is a method. | `"obj_j"` |
 | result_name | If not using `result` what should be used (optional) | `"my_result"` |
-| return_type | C++ return type | `double` |
+| return_type | C++ return type (including pointer, etc.) or collection element type depending on `return_is_collection`. | `double` |
 | return_is_collection | If true, then the return is a collection of `return_type` | `True` |
 
 Note that a very simple replacement is done for `result_name` - so it needs to be a totally unique name. The back-end may well change `result` to some other name (like `r232`) depending on the complexity of the expression being parsed.

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -393,8 +393,8 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
             return r
 
         # If it isn't a sequence or a collection, then something has gone wrong.
-        raise Exception(
-            f"Unable to generate a sequence from the given AST. Either there is an internal error, or you are trying to manipulate a {str(rep)} ('{type(rep).__name__}') as a sequence (ast is: {ast.dump(generation_ast)})"
+        raise ValueError(
+            f"Unable to generate a sequence from the given AST. Either there is an internal error, or you are trying to manipulate a {str(rep)} ('{type(rep).__name__}') as a sequence (ast is: {ast.unparse(generation_ast)})"
         )
 
     def visit_Call_Lambda(self, call_node: ast.Call):

--- a/func_adl_xAOD/common/cpp_ast.py
+++ b/func_adl_xAOD/common/cpp_ast.py
@@ -86,10 +86,7 @@ class CPPCodeSpecification:
     result: str
 
     # The type of the result variable, or if a collection, of the values
-    cpp_return_type: str
-
-    # The pointer depth. 0 means no indirection needed.
-    cpp_return_p_depth: int
+    cpp_return_type: ctyp.CPPParsedTypeInfo
 
     # True if this is a collection return type. In that case, the collection is expected
     # to obey vector like semantics

--- a/func_adl_xAOD/common/cpp_ast.py
+++ b/func_adl_xAOD/common/cpp_ast.py
@@ -26,7 +26,7 @@ class CPPCodeValue(ast.AST):
     Represents a C++ bit of code that returns a value. Like a function call or a member call.
     Use the be-fore the wire visit phase of processing to look for a pattern that needs
     to generate AST code, like a method call. Then place this AST in place of the function.
-    The back-end will then do the rendering useing the information included below.
+    The back-end will then do the rendering using the information included below.
 
     TODO: This should be a dataclass!
     """
@@ -255,7 +255,7 @@ def process_ast_node(visitor, gc, call_node: ast.Call):
             l_s = l_s.replace(src, str(dest))
         blk.add_statement(statements.arbitrary_statement(l_s))
 
-    # Emit the instance declaration and intialization code.
+    # Emit the instance declaration and initialization code.
     for i in cpp_ast_node.fields:
         l_s = i[1]
         gc.declare_class_variable(i[0])

--- a/func_adl_xAOD/common/cpp_ast.py
+++ b/func_adl_xAOD/common/cpp_ast.py
@@ -7,8 +7,11 @@ from typing import Callable, Dict, List, Optional, cast
 
 import func_adl_xAOD.common.cpp_types as ctyp
 import func_adl_xAOD.common.statement as statements
-from func_adl_xAOD.common.cpp_representation import (cpp_collection, cpp_value,
-                                                     cpp_variable)
+from func_adl_xAOD.common.cpp_representation import (
+    cpp_collection,
+    cpp_value,
+    cpp_variable,
+)
 from func_adl_xAOD.common.cpp_vars import unique_name
 from func_adl_xAOD.common.util_scope import gc_scope
 
@@ -18,15 +21,15 @@ from func_adl_xAOD.common.util_scope import gc_scope
 method_names = {}
 
 
-class CPPCodeValue (ast.AST):
-    r'''
+class CPPCodeValue(ast.AST):
+    r"""
     Represents a C++ bit of code that returns a value. Like a function call or a member call.
     Use the be-fore the wire visit phase of processing to look for a pattern that needs
     to generate AST code, like a method call. Then place this AST in place of the function.
     The back-end will then do the rendering useing the information included below.
 
     TODO: This should be a dataclass!
-    '''
+    """
 
     def __init__(self):
         # Files that need to be included at the top of the generated C++ file
@@ -85,6 +88,9 @@ class CPPCodeSpecification:
     # The type of the result variable, or if a collection, of the values
     cpp_return_type: str
 
+    # The pointer depth. 0 means no indirection needed.
+    cpp_return_p_depth: int
+
     # True if this is a collection return type. In that case, the collection is expected
     # to obey vector like semantics
     cpp_return_is_collection: bool = False
@@ -97,7 +103,7 @@ class CPPCodeSpecification:
 
 
 def build_CPPCodeValue(spec: CPPCodeSpecification, call_node: ast.Call) -> ast.Call:
-    '''
+    """
     Given the specification for a C++ code block, invoked as a function in our AST, replace
     the call node with a cpp spec callback AST so the C++ code is properly inserted into the
     call stream.
@@ -113,16 +119,22 @@ def build_CPPCodeValue(spec: CPPCodeSpecification, call_node: ast.Call) -> ast.C
 
     Returns:
         [type]: The C++ ast that can easily be emitted as code
-    '''
+    """
 
     if len(call_node.args) != len(spec.arguments):
-        raise ValueError(f"The call of {spec.name}({', '.join(spec.arguments)}) has insufficient arguments ({len(call_node.args)}).")
+        raise ValueError(
+            f"The call of {spec.name}({', '.join(spec.arguments)}) has insufficient arguments ({len(call_node.args)})."
+        )
 
     if isinstance(call_node.func, ast.Attribute) and spec.method_object is None:
-        raise ValueError(f"The {spec.name} is a function, but it is invoked like a method.")
+        raise ValueError(
+            f"The {spec.name} is a function, but it is invoked like a method."
+        )
 
     if isinstance(call_node.func, ast.Name) and spec.method_object is not None:
-        raise ValueError(f"The {spec.name} is a method, but it is invoked like a function.")
+        raise ValueError(
+            f"The {spec.name} is a method, but it is invoked like a function."
+        )
 
     # Create an AST to hold onto all of this.
     r = CPPCodeValue()
@@ -138,9 +150,13 @@ def build_CPPCodeValue(spec: CPPCodeSpecification, call_node: ast.Call) -> ast.C
     if spec.cpp_return_is_collection:
         r.result_rep = lambda scope: cpp_collection(unique_name(spec.name), scope=scope, collection_type=ctyp.collection(ctyp.terminal(spec.cpp_return_type)))  # type: ignore
     else:
-        r.result_rep = lambda scope: cpp_variable(unique_name(spec.name), scope=scope, cpp_type=ctyp.terminal(spec.cpp_return_type))
+        r.result_rep = lambda scope: cpp_variable(
+            unique_name(spec.name),
+            scope=scope,
+            cpp_type=ctyp.terminal(spec.cpp_return_type),
+        )
 
-    # If this is a mehtod, copy the info over to generate the obj reference.
+    # If this is a method, copy the info over to generate the obj reference.
     if spec.method_object is not None:
         r.replacement_instance_obj = (spec.method_object, call_node.func.value.id)  # type: ignore
 
@@ -149,26 +165,27 @@ def build_CPPCodeValue(spec: CPPCodeSpecification, call_node: ast.Call) -> ast.C
 
 
 class cpp_ast_finder(ast.NodeTransformer):
-    r'''
+    r"""
     Look through the complete ast and replace method calls that are to a C++ plug in with a c++ ast
     node.
-    '''
+    """
+
     def __init__(self, method_names: Dict[str, Callable[[ast.Call], ast.Call]]):
         self._method_names = method_names
 
     def try_call(self, name, node):
-        'Try to use name to do the call. Returns (ok, result) monad'
+        "Try to use name to do the call. Returns (ok, result) monad"
         if name in self._method_names:
             cpp_call_ast = self._method_names[name](node)
             return (cpp_call_ast is not None, cpp_call_ast)
         return (False, None)
 
     def visit_Call(self, node):
-        r'''
+        r"""
         Looking for a member call of a particular name. We rewrite that as
         another name.
         WARNING: currently the namespace is global, so the parent type doesn't matter!
-        '''
+        """
 
         # Make sure all parts of this AST are visited properly before we attempt to
         # understand the call.
@@ -189,7 +206,7 @@ class cpp_ast_finder(ast.NodeTransformer):
 
 
 def process_ast_node(visitor, gc, call_node: ast.Call):
-    r'''Inject the proper code into the output stream to deal with this C++ code.
+    r"""Inject the proper code into the output stream to deal with this C++ code.
 
     We expect this to be run on the back-end of the system.
 
@@ -199,7 +216,7 @@ def process_ast_node(visitor, gc, call_node: ast.Call):
 
     Result:
     representation - A value that represents the output
-    '''
+    """
 
     # We write everything into a new scope to prevent conflicts. So we have to declare the result ahead of time.
     cpp_ast_node = cast(CPPCodeValue, call_node.func)
@@ -217,7 +234,14 @@ def process_ast_node(visitor, gc, call_node: ast.Call):
     # against, if any.
     repl_list = []
     if cpp_ast_node.replacement_instance_obj is not None:
-        repl_list += [(cpp_ast_node.replacement_instance_obj[0], visitor.resolve_id(cpp_ast_node.replacement_instance_obj[1]).rep.as_cpp())]
+        repl_list += [
+            (
+                cpp_ast_node.replacement_instance_obj[0],
+                visitor.resolve_id(
+                    cpp_ast_node.replacement_instance_obj[1]
+                ).rep.as_cpp(),
+            )
+        ]
 
     # Process the arguments that are getting passed to the function
     for arg, dest in zip(cpp_ast_node.args, call_node.args):
@@ -245,7 +269,12 @@ def process_ast_node(visitor, gc, call_node: ast.Call):
 
     # Set the result and close the scope
     assert cpp_ast_node.result is not None
-    blk.add_statement(statements.set_var(result_rep, cpp_value(cpp_ast_node.result, gc.current_scope(), result_rep.cpp_type())))
+    blk.add_statement(
+        statements.set_var(
+            result_rep,
+            cpp_value(cpp_ast_node.result, gc.current_scope(), result_rep.cpp_type()),
+        )
+    )
     gc.pop_scope()
 
     return result_rep

--- a/func_adl_xAOD/common/cpp_functions.py
+++ b/func_adl_xAOD/common/cpp_functions.py
@@ -1,8 +1,10 @@
-# Infrastructure to replace simple functions (like "abs") in python with their
-# equivalent in C++.
 import ast
 from collections import namedtuple
+
 from func_adl_xAOD.common.cpp_types import terminal
+
+# Infrastructure to replace simple functions (like "abs") in python with their
+# equivalent in C++.
 
 
 class FunctionAST(ast.AST):
@@ -61,11 +63,13 @@ def add_function_mapping(python_name, cpp_name, include_files, return_type):
     global functions_to_replace
     functions_to_replace[python_name] = cpp_function(
         cpp_name,
-        include_files
-        if type(include_files) is list
-        else [
-            include_files,
-        ],
+        (
+            include_files
+            if type(include_files) is list
+            else [
+                include_files,
+            ]
+        ),
         terminal(return_type),
     )
 

--- a/func_adl_xAOD/common/cpp_functions.py
+++ b/func_adl_xAOD/common/cpp_functions.py
@@ -60,7 +60,7 @@ def add_function_mapping(python_name, cpp_name, include_files, return_type):
     include_files: any include files that should be included in the C++ source. Can also be a single string.
     return_type: C++ return type
     """
-    global functions_to_replace
+    global functions_to_replace  # noqa
     functions_to_replace[python_name] = cpp_function(
         cpp_name,
         (

--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -58,6 +58,7 @@ from func_adl_xAOD.common.util_scope import gc_scope, gc_scope_top_level
 
 class dummy_ast(ast.AST):
     "A dummy ast"
+
     _fields = tuple()
 
     def __init__(self, node: cpp_rep_base):
@@ -314,7 +315,7 @@ class cpp_sequence(cpp_rep_base):
         iterator_value:         The iterator that is incremented to get the next value in the sequence. The
                                 iterators scope is defined where it was created.
         scope:                  The scope at which this sequence is declared. Note that this may be different
-                                from the of the interator if we are, for example, inside an if statement caused
+                                from the of the iterator if we are, for example, inside an if statement caused
                                 by a Where (or similar). If the `sequence_value` is an actual value, it will have
                                 the same scope.
         """

--- a/func_adl_xAOD/common/math_utils.py
+++ b/func_adl_xAOD/common/math_utils.py
@@ -2,6 +2,7 @@
 import ast
 from typing import Callable, Dict
 import func_adl_xAOD.common.cpp_ast as cpp_ast
+from func_adl_xAOD.common.cpp_types import parse_type
 
 
 DeltaRSpec = cpp_ast.CPPCodeSpecification(
@@ -14,8 +15,7 @@ DeltaRSpec = cpp_ast.CPPCodeSpecification(
         "auto result = sqrt(d_eta*d_eta + d_phi*d_phi);",
     ],
     "result",
-    "double",
-    0,
+    parse_type("double"),
 )
 
 

--- a/func_adl_xAOD/common/math_utils.py
+++ b/func_adl_xAOD/common/math_utils.py
@@ -5,25 +5,26 @@ import func_adl_xAOD.common.cpp_ast as cpp_ast
 
 
 DeltaRSpec = cpp_ast.CPPCodeSpecification(
-    'DeltaR',
-    ['TVector2.h', 'math.h'],
-    ['eta1', 'phi1', 'eta2', 'phi2'],
+    "DeltaR",
+    ["TVector2.h", "math.h"],
+    ["eta1", "phi1", "eta2", "phi2"],
     [
-        'auto d_eta = eta1 - eta2;',
-        'auto d_phi = TVector2::Phi_mpi_pi(phi1-phi2);',
-        'auto result = sqrt(d_eta*d_eta + d_phi*d_phi);'
+        "auto d_eta = eta1 - eta2;",
+        "auto d_phi = TVector2::Phi_mpi_pi(phi1-phi2);",
+        "auto result = sqrt(d_eta*d_eta + d_phi*d_phi);",
     ],
-    'result',
-    'double'
+    "result",
+    "double",
+    0,
 )
 
 
 def DeltaR(eta1, phi1, eta2, phi2) -> float:
-    'Calculate the DeltaR between two eta,phi specified vectors'
-    raise NotImplementedError('DeltaR should never be called in python!')
+    "Calculate the DeltaR between two eta,phi specified vectors"
+    raise NotImplementedError("DeltaR should never be called in python!")
 
 
 def get_math_methods() -> Dict[str, Callable[[ast.Call], ast.Call]]:
     return {
-        'DeltaR': lambda call_node: cpp_ast.build_CPPCodeValue(DeltaRSpec, call_node)
+        "DeltaR": lambda call_node: cpp_ast.build_CPPCodeValue(DeltaRSpec, call_node)
     }

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -144,6 +144,11 @@ def process_metadata(
                 md["result_name"] if "result_name" in md else "result",
                 md["return_type"],
                 (
+                    int(md["return_pointer_depth"])
+                    if "return_pointer_depth" in md
+                    else int(0)
+                ),
+                (
                     bool(md["return_is_collection"])
                     if "return_is_collection" in md
                     else False

--- a/func_adl_xAOD/common/meta_data.py
+++ b/func_adl_xAOD/common/meta_data.py
@@ -142,12 +142,7 @@ def process_metadata(
                 md["arguments"],
                 md["code"],
                 md["result_name"] if "result_name" in md else "result",
-                md["return_type"],
-                (
-                    int(md["return_pointer_depth"])
-                    if "return_pointer_depth" in md
-                    else int(0)
-                ),
+                parse_type(md["return_type"]),
                 (
                     bool(md["return_is_collection"])
                     if "return_is_collection" in md

--- a/tests/atlas/xaod/test_local_dataset.py
+++ b/tests/atlas/xaod/test_local_dataset.py
@@ -92,7 +92,7 @@ def test_run_docker_md(docker_mock):
         .value()
     )
 
-    global docker_mock_args
+    global docker_mock_args  # noqa
     assert docker_mock_args[0] == "crazy/atlas:latest"
 
 

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -648,8 +648,7 @@ def test_md_function_call():
     assert spec.arguments == ["eta1", "phi1", "eta2", "phi2"]
     assert len(spec.code) == 3
     assert spec.result == "result"
-    assert spec.cpp_return_p_depth == 0
-    assert spec.cpp_return_type == "double"
+    assert spec.cpp_return_type.name == "double"
 
 
 def test_md_function_call_pointer():
@@ -674,8 +673,8 @@ def test_md_function_call_pointer():
     assert len(specs) == 1
     spec = specs[0]
     assert isinstance(spec, CPPCodeSpecification)
-    assert spec.cpp_return_p_depth == 1
-    assert spec.cpp_return_type == "double*"
+    assert spec.cpp_return_type.pointer_depth == 1
+    assert spec.cpp_return_type.name == "double"
 
 
 def test_md_method_call():

--- a/tests/common/test_meta_data.py
+++ b/tests/common/test_meta_data.py
@@ -648,7 +648,34 @@ def test_md_function_call():
     assert spec.arguments == ["eta1", "phi1", "eta2", "phi2"]
     assert len(spec.code) == 3
     assert spec.result == "result"
+    assert spec.cpp_return_p_depth == 0
     assert spec.cpp_return_type == "double"
+
+
+def test_md_function_call_pointer():
+    "Inject code to run some C++"
+    metadata = [
+        {
+            "metadata_type": "add_cpp_function",
+            "name": "MyDeltaR",
+            "include_files": ["TVector2.h", "math.h"],
+            "arguments": ["eta1", "phi1", "eta2", "phi2"],
+            "code": [
+                "auto d_eta = eta1 - eta2;",
+                "auto d_phi = TVector2::Phi_mpi_pi(phi1-phi2);",
+                "auto result = sqrt(d_eta*d_eta + d_phi*d_phi);",
+            ],
+            "return_type": "double*",
+            "return_pointer_depth": 1,
+        }
+    ]
+
+    specs = process_metadata(metadata)
+    assert len(specs) == 1
+    spec = specs[0]
+    assert isinstance(spec, CPPCodeSpecification)
+    assert spec.cpp_return_p_depth == 1
+    assert spec.cpp_return_type == "double*"
 
 
 def test_md_method_call():


### PR DESCRIPTION
* Can now deal with a pointer in return from a C++ injected code function.
* Does this by parsing the `return_type` in the `add_cpp_function` metadata.

Also

* Minor clean up due to `black` and some spelling errors
* force install `docker` on macOS. Weird that I have to do that.
* Clean up of an error message

Fixes #242
