### PR TITLE
Use regular expressions for variable replacement

### DIFF
--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -277,7 +277,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
             ast_ttree = function_call(
                 "ResultTTree",
                 [
-                    node,
+                    node,  # type: ignore
                     col_names,
                     ast.parse(f'"{self._prefix}_tree"').body[0].value,  # type: ignore
                     ast.parse(f'"{self._prefix}_output"').body[0].value,  # type: ignore
@@ -292,7 +292,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
             ast_ttree = function_call(
                 "ResultTTree",
                 [
-                    node,
+                    node,  # type: ignore
                     ast.parse('"col1"').body[0].value,  # type: ignore
                     ast.parse(f'"{self._prefix}_tree"').body[0].value,  # type: ignore
                     ast.parse(f'"{self._prefix}_output"').body[0].value,  # type: ignore

--- a/func_adl_xAOD/common/cpp_ast.py
+++ b/func_adl_xAOD/common/cpp_ast.py
@@ -3,6 +3,7 @@
 # This is one mechanism to allow for a leaky abstraction.
 import ast
 from dataclasses import dataclass
+import re
 from typing import Callable, Dict, List, Optional, cast
 
 import func_adl_xAOD.common.cpp_types as ctyp
@@ -252,7 +253,7 @@ def process_ast_node(visitor, gc, call_node: ast.Call):
     for s in cpp_ast_node.running_code:
         l_s = s
         for src, dest in repl_list:
-            l_s = l_s.replace(src, str(dest))
+            l_s = re.sub(rf"\b{re.escape(src)}\b", str(dest), l_s)
         blk.add_statement(statements.arbitrary_statement(l_s))
 
     # Emit the instance declaration and initialization code.
@@ -260,7 +261,7 @@ def process_ast_node(visitor, gc, call_node: ast.Call):
         l_s = i[1]
         gc.declare_class_variable(i[0])
         for src, dest in repl_list:
-            l_s = l_s.replace(src, str(dest))
+            l_s = re.sub(rf"\b{re.escape(src)}\b", str(dest), l_s)
         token_set_var = statements.set_var(i[0], cpp_value(l_s, None, None))
         gc.add_book_statement(token_set_var)
 

--- a/tests/cms/miniaod/test_miniaod_executor.py
+++ b/tests/cms/miniaod/test_miniaod_executor.py
@@ -2,8 +2,10 @@ import pytest
 from func_adl_xAOD.cms.miniaod import isNonnull
 from tests.cms.miniaod.utils import cms_miniaod_dataset  # type: ignore
 from tests.utils.general import get_lines_of_code, print_lines  # type: ignore
-from tests.utils.locators import (find_line_with,  # type: ignore
-                                  find_next_closing_bracket)
+from tests.utils.locators import (
+    find_line_with,  # type: ignore
+    find_next_closing_bracket,
+)
 
 
 # Tests that make sure the cms aod executor is working correctly
@@ -13,24 +15,38 @@ class CMS_miniAOD_File_Type:
 
 
 def test_Select_member_variable():
-    r = cms_miniaod_dataset() \
-        .SelectMany(lambda e: e.Muons("slimmedMuons")) \
-        .Select(lambda m: m.pfIsolationR04().sumChargedHadronPt) \
+    r = (
+        cms_miniaod_dataset()
+        .SelectMany(lambda e: e.Muons("slimmedMuons"))
+        .Select(lambda m: m.pfIsolationR04().sumChargedHadronPt)
         .value()
+    )
     lines = get_lines_of_code(r)
     _ = find_line_with(".sumChargedHadronPt", lines)
-    assert find_line_with(".sumChargedHadronPt()", lines, throw_if_not_found=False) == -1
+    assert (
+        find_line_with(".sumChargedHadronPt()", lines, throw_if_not_found=False) == -1
+    )
 
 
 def test_complex_dict():
-    'Seen to fail in the wild, so a test case to track'
-    r = cms_miniaod_dataset() \
-        .Select(lambda e: {"muons": e.Muons("slimmedMuons"), "primvtx": e.Vertex("offlinePrimaryVertices")}) \
-        .Select(lambda i: i.muons
-                .Where(lambda m: isNonnull(m.globalTrack()))
-                .Select(lambda m: m.globalTrack().dx(i.primvtx[0].position()))
-                ) \
+    "Seen to fail in the wild, so a test case to track"
+    r = (
+        cms_miniaod_dataset()
+        .Select(
+            lambda e: {
+                "muons": e.Muons("slimmedMuons"),
+                "primvtx": e.Vertex("offlinePrimaryVertices"),
+            }
+        )
+        .Select(
+            lambda i: i.muons.Where(  # type: ignore
+                lambda m: isNonnull(m.globalTrack())
+            ).Select(
+                lambda m: m.globalTrack().dx(i.primvtx[0].position())  # type: ignore
+            )
+        )
         .value()
+    )
     lines = get_lines_of_code(r)
     print_lines(lines)
 
@@ -39,53 +55,68 @@ def test_complex_dict():
 
 
 def test_2nd_order_lookup():
-    'Seen in the wild to generate an out-of-scope error'
-    r = (cms_miniaod_dataset()
-         .Select(lambda e: {"m": e.Muons("slimmedMuons"), "p": e.Vertex("offlinePrimaryVertices")[0].position()})
-         .Select(lambda i:
-                 i.m
-                 .Where(lambda m: m.isPFMuon()
-                        and m.isPFIsolationValid()
-                        and isNonnull(m.globalTrack())
-                        and abs((m.globalTrack()).dxy(i.p)) < 0.5
-                        and abs((m.globalTrack()).dz(i.p)) < 1.
-                        )
-                 .Select(lambda m: m.p()),
-                 )
-         .value()
-         )
+    "Seen in the wild to generate an out-of-scope error"
+    r = (
+        cms_miniaod_dataset()
+        .Select(
+            lambda e: {
+                "m": e.Muons("slimmedMuons"),
+                "p": e.Vertex("offlinePrimaryVertices")[0].position(),
+            }
+        )
+        .Select(
+            lambda i: i.m.Where(  # type: ignore
+                lambda m: m.isPFMuon()
+                and m.isPFIsolationValid()
+                and isNonnull(m.globalTrack())
+                and abs((m.globalTrack()).dxy(i.p)) < 0.5  # type: ignore
+                and abs((m.globalTrack()).dz(i.p)) < 1.0  # type: ignore
+            ).Select(lambda m: m.p()),
+        )
+        .value()
+    )
 
     lines = get_lines_of_code(r)
     print_lines(lines)
 
     # Make sure the vertex line isn't used after it goes out of scope
-    vertex_decl_line = find_line_with('Handle<reco::VertexCollection>', lines)
+    vertex_decl_line = find_line_with("Handle<reco::VertexCollection>", lines)
 
-    vertex_variable_name = lines[vertex_decl_line].split(' ')[-1].strip(';')
+    vertex_variable_name = lines[vertex_decl_line].split(" ")[-1].strip(";")
 
     closing_scope = find_next_closing_bracket(lines[vertex_decl_line:])
-    vertex_used_too_late = find_line_with(vertex_variable_name, lines[vertex_decl_line + closing_scope:], throw_if_not_found=False)
+    vertex_used_too_late = find_line_with(
+        vertex_variable_name,
+        lines[vertex_decl_line + closing_scope :],  # noqa
+        throw_if_not_found=False,
+    )
     if vertex_used_too_late != -1:
-        print('Here is where it is used and down')
-        print_lines(lines[closing_scope + vertex_decl_line + vertex_used_too_late:])
+        print("Here is where it is used and down")
+        print_lines(
+            lines[closing_scope + vertex_decl_line + vertex_used_too_late :]  # noqa
+        )
     assert vertex_used_too_late == -1
 
 
 def test_metadata_collection():
-    'This is integration testing - making sure the dict to root conversion works'
-    r = (cms_miniaod_dataset()
-         .MetaData({
-                   'metadata_type': 'add_cms_miniaod_event_collection_info',
-                   'name': 'ForkVertex',
-                   'include_files': ['DataFormats/VertexReco/interface/Vertex.h'],
-                   'container_type': 'reco::VertexCollection',
-                   'contains_collection': True,
-                   'element_type': 'reco::Vertex',
-                   'element_pointer': False,
-                   })
-         .Select(lambda e: e.ForkVertex("EventInfo").Count())
-         .Select(lambda e: {'run_number': e})
-         .value())
+    "This is integration testing - making sure the dict to root conversion works"
+    r = (
+        cms_miniaod_dataset()
+        .MetaData(
+            {
+                "metadata_type": "add_cms_miniaod_event_collection_info",
+                "name": "ForkVertex",
+                "include_files": ["DataFormats/VertexReco/interface/Vertex.h"],
+                "container_type": "reco::VertexCollection",
+                "contains_collection": True,
+                "element_type": "reco::Vertex",
+                "element_pointer": False,
+            }
+        )
+        .Select(lambda e: e.ForkVertex("EventInfo").Count())
+        .Select(lambda e: {"run_number": e})
+        .value()
+    )
     vs = r.QueryVisitor._gc._class_vars
     print(vs[0].cpp_type())
     assert 2 == len(vs)
@@ -94,18 +125,22 @@ def test_metadata_collection():
 
 
 def test_metadata_collection_bad_experiment():
-    'This is integration testing - making sure the dict to root conversion works'
+    "This is integration testing - making sure the dict to root conversion works"
     with pytest.raises(ValueError) as e:
-        (cms_miniaod_dataset()
-         .MetaData({
-                   'metadata_type': 'add_atlas_event_collection_info',
-                   'name': 'ForkInfo',
-                   'include_files': ['xAODEventInfo/EventInfo.h'],
-                   'container_type': 'xAOD::EventInfo',
-                   'contains_collection': False,
-                   })
-         .Select(lambda e: e.ForkInfo("EventInfo").runNumber())
-         .Select(lambda e: {'run_number': e})
-         .value())
+        (
+            cms_miniaod_dataset()
+            .MetaData(
+                {
+                    "metadata_type": "add_atlas_event_collection_info",
+                    "name": "ForkInfo",
+                    "include_files": ["xAODEventInfo/EventInfo.h"],
+                    "container_type": "xAOD::EventInfo",
+                    "contains_collection": False,
+                }
+            )
+            .Select(lambda e: e.ForkInfo("EventInfo").runNumber())
+            .Select(lambda e: {"run_number": e})
+            .value()
+        )
 
     assert "backend; only" in str(e.value)


### PR DESCRIPTION
* Replace string replacement with regular expressions to ensure accurate variable substitution in the code processing logic.

* Fix up observed pylance type errors

Fixes #246