### PR TITLE
Use `ast.unparse` rather than `ast.dump`

### DIFF
--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -201,7 +201,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         # If it didn't work, this is an internal error. But make the error message a bit nicer.
         if not hasattr(node, "rep"):
             raise Exception(
-                f'Internal Error: attempted to get C++ representation for AST node "{ast.dump(node)}", but failed.'
+                f'Internal Error: attempted to get C++ representation for AST node "{ast.unparse(node)}", but failed.'
             )
 
         return crep.get_rep(node)
@@ -712,7 +712,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
             r = FuncADLNodeVisitor.visit_Call(self, call_node)
             if r is None and not hasattr(call_node, "rep"):
                 raise Exception(
-                    f"Do not know how to call '{ast.dump(call_node.func, annotate_fields=False)}'"
+                    f"Do not know how to call '{ast.unparse(call_node.func)}'"
                 )
             if r is not None:
                 crep.set_rep(call_node, r)
@@ -858,7 +858,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
 
         else:
             raise Exception(
-                f"Do not know how to translate Binary operator {ast.dump(node.op)}!"
+                f"Do not know how to translate Binary operator {ast.unparse(node)}!"
             )
 
     def visit_BinOp(self, node: ast.BinOp):
@@ -886,7 +886,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
     def visit_UnaryOp(self, node: ast.UnaryOp):
         if type(node.op) not in _known_unary_operators:
             raise Exception(
-                f"Do not know how to translate Unary operator {ast.dump(node.op)}!"
+                f"Do not know how to translate Unary operator {ast.unparse(node.op)}!"
             )
 
         operand = cast(crep.cpp_value, self.get_rep(node.operand))
@@ -1444,7 +1444,7 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         )
         fail.add_statement(
             statement.arbitrary_statement(
-                f'throw std::runtime_error("First() called on an empty sequence ({ast.dump(node)})");'
+                f'throw std::runtime_error("First() called on an empty sequence ({ast.unparse(node)})");'
             )
         )
         outside_block_scope.frame_statements(-1).add_statement(fail)

--- a/func_adl_xAOD/common/executor.py
+++ b/func_adl_xAOD/common/executor.py
@@ -81,11 +81,11 @@ def _is_format_request(a: ast.AST) -> bool:
     """
     if not isinstance(a, ast.Call):
         raise ValueError(
-            f"A func_adl ast must start with a function call. This does not: {ast.dump(a)}"
+            f"A func_adl ast must start with a function call. This does not: {ast.unparse(a)}"
         )
     if not isinstance(a.func, ast.Name):
         raise ValueError(
-            f"A func_adl ast must start with a function call to something like Select or AsROOTTTree. This does not: {ast.dump(a)}"
+            f"A func_adl ast must start with a function call to something like Select or AsROOTTTree. This does not: {ast.unparse(a)}"
         )
     return a.func.id == "ResultTTree"
 

--- a/tests/atlas/xaod/test_atlas_xaod_exectuor.py
+++ b/tests/atlas/xaod/test_atlas_xaod_exectuor.py
@@ -80,7 +80,9 @@ def test_bad_ast_no_call_to_name(tmp_path):
     # Get the ast to play with
     q = query_as_ast()
     a = ast.Call(
-        func=ast.Attribute(value=ast.Constant(10), attr="fork"), args=[q.query_ast]
+        func=ast.Attribute(value=ast.Constant(10), attr="fork"),
+        args=[q.query_ast],
+        keywords=[],
     )
 
     exe = atlas_xaod_executor()

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -651,7 +651,7 @@ def test_generate_binary_operator_unsupported():
             lambda e: e.Jets("AntiKt4EMTopoJets").Select(lambda j: j.pt() // 2)
         ).value()
 
-    assert "FloorDiv" in str(e)
+    assert "//" in str(e)
 
 
 def test_generate_unary_operations():


### PR DESCRIPTION
* `ast.dump` makes for a much more user-friendly error message. Replace `ast.dump`.
* Fix up a few tests that broke as a result of specific text no longer being present in error messages.

Fixes #240