### PR TITLE
Change default behavior of tests so docker stuff does not run.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,8 @@ jobs:
       - name: Test with pytest
         run: |
           # python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
-          python -m pytest -m "atlas_xaod_runner"
+          # python -m pytest -m "atlas_xaod_runner"
+          pytest tests/atlas/xaod/test_cpp_script_control.py::test_good_cpp_compile_and_run_2_files -m atlas_xaod_runner
       - name: Report coverage with Codecov
         if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         # platform: [ubuntu-latest, macOS-latest, windows-latest]
-        platform: [ubuntu-latest]
+        platform: [windows-latest]
         # python-version: [3.9, "3.10", "3.11", "3.12"]
         python-version: ["3.12"]
     runs-on: ${{ matrix.platform }}
@@ -78,6 +78,7 @@ jobs:
         run: brew install docker
       - name: Test with pytest
         run: |
+          python -m pytest
           python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
       - name: Report coverage with Codecov
         if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,9 +78,7 @@ jobs:
         run: brew install docker
       - name: Test with pytest
         run: |
-          # python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
-          # python -m pytest -m "atlas_xaod_runner"
-          pytest tests/atlas/xaod/test_cpp_script_control.py::test_good_cpp_compile_and_run_2_files -m atlas_xaod_runner
+          python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
       - name: Report coverage with Codecov
         if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,8 +79,7 @@ jobs:
       - name: Test with pytest
         run: |
           # python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
-          # python -m pytest -m "atlas_xaod_runner"
-          pytest -m "atlas_xaod_runner" tests/atlas/xaod/test_cpp_script_control.py::test_good_cpp_total_run_output_dir
+          python -m pytest -m "atlas_xaod_runner"
       - name: Report coverage with Codecov
         if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,8 @@ jobs:
   test-with-docker:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macOS-latest, windows-latest]
+        # platform: [ubuntu-latest, macOS-latest, windows-latest]
+        platform: [ubuntu-latest]
         python-version: [3.9, "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.platform }}
     needs: flake8
@@ -76,7 +77,8 @@ jobs:
         run: brew install docker
       - name: Test with pytest
         run: |
-          python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
+          # python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
+          python -m pytest -m "atlas_xaod_runner"
       - name: Report coverage with Codecov
         if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         # platform: [ubuntu-latest, macOS-latest, windows-latest]
-        platform: [ubuntu-latest]
+        platform: [windows-latest]
         python-version: [3.9, "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.platform }}
     needs: flake8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,8 @@ jobs:
       matrix:
         # platform: [ubuntu-latest, macOS-latest, windows-latest]
         platform: [ubuntu-latest]
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        # python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
     runs-on: ${{ matrix.platform }}
     needs: flake8
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,8 @@ jobs:
       - name: Test with pytest
         run: |
           # python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
-          python -m pytest -m "atlas_xaod_runner"
+          # python -m pytest -m "atlas_xaod_runner"
+          pytest tests/atlas/xaod/test_cpp_script_control.py::test_good_cpp_total_run_output_dir
       - name: Report coverage with Codecov
         if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         # platform: [ubuntu-latest, macOS-latest, windows-latest]
-        platform: [windows-latest]
+        platform: [ubuntu-latest]
         python-version: [3.9, "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.platform }}
     needs: flake8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
         run: |
           # python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
           # python -m pytest -m "atlas_xaod_runner"
-          pytest tests/atlas/xaod/test_cpp_script_control.py::test_good_cpp_total_run_output_dir
+          pytest -m "atlas_xaod_runner" tests/atlas/xaod/test_cpp_script_control.py::test_good_cpp_total_run_output_dir
       - name: Report coverage with Codecov
         if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,9 +71,9 @@ jobs:
           pip install git+https://github.com/iris-hep/ast-language.git@e6470deb68529e1885a4bc46f781e2fe43a6f4c8
           pip install --no-cache-dir -e .[test,local]
           pip list
-      # - name: Install Docker on macOS
-      #   if: matrix.platform == 'macOS-latest'
-      #   run: brew install docker
+      - name: Install Docker on macOS
+        if: matrix.platform == 'macOS-latest'
+        run: brew install docker
       - name: Test with pytest
         run: |
           python -m pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,9 @@ name: CI/CD
 
 on:
   push:
-  pull_request:
+    branches:
+      - master  # Only run on push to master
+  pull_request:  # Run on all pull requests
   # Run daily at 0:01 UTC
   schedule:
     - cron: "1 0 * * 0"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
           pip list
       - name: Test with pytest
         run: |
-          python -m pytest -m "not atlas_xaod_runner and not atlas_r22_xaod_runner and not cms_aod_runner and not cms_miniaod_runner"
+          python -m pytest
 
   test-with-docker:
     strategy:
@@ -74,7 +74,7 @@ jobs:
         run: brew install docker
       - name: Test with pytest
         run: |
-          python -m pytest -m "not atlas_xaod_runner and not atlas_r22_xaod_runner and not cms_aod_runner and not cms_miniaod_runner"
+          python -m pytest -m "atlas_xaod_runner and atlas_r22_xaod_runner and cms_aod_runner and cms_miniaod_runner"
       - name: Report coverage with Codecov
         if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
         run: brew install docker
       - name: Test with pytest
         run: |
-          python -m pytest -m "atlas_xaod_runner and atlas_r22_xaod_runner and cms_aod_runner and cms_miniaod_runner"
+          python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
       - name: Report coverage with Codecov
         if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,10 +54,8 @@ jobs:
   test-with-docker:
     strategy:
       matrix:
-        # platform: [ubuntu-latest, macOS-latest, windows-latest]
-        platform: [windows-latest]
-        # python-version: [3.9, "3.10", "3.11", "3.12"]
-        python-version: ["3.12"]
+        platform: [ubuntu-latest, macOS-latest, windows-latest]
+        python-version: [3.9, "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.platform }}
     needs: flake8
 
@@ -73,13 +71,15 @@ jobs:
           pip install git+https://github.com/iris-hep/ast-language.git@e6470deb68529e1885a4bc46f781e2fe43a6f4c8
           pip install --no-cache-dir -e .[test,local]
           pip list
-      - name: Install Docker on macOS
-        if: matrix.platform == 'macOS-latest'
-        run: brew install docker
+      # - name: Install Docker on macOS
+      #   if: matrix.platform == 'macOS-latest'
+      #   run: brew install docker
       - name: Test with pytest
         run: |
           python -m pytest
-          python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
+          # These now take too long, and macOS and Windows both don't have docker installed
+          # or installed correctly.
+          # python -m pytest -m "atlas_xaod_runner or atlas_r22_xaod_runner or cms_aod_runner or cms_miniaod_runner"
       - name: Report coverage with Codecov
         if: github.event_name == 'push' && matrix.python-version == 3.9 && matrix.platform == 'ubuntu-latest'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.platform }}
     needs: flake8
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
-addopts = --ignore=setup.py --cov=func_adl_xAOD --cov-report=term-missing --cov-config=.coveragerc --cov-report xml
 junit_family=legacy
+addopts = -m "not atlas_xaod_runner and not atlas_r22_xaod_runner and not cms_aod_runner and not cms_miniaod_runner"
 markers = 
   atlas_xaod_runner: Run ATLAS R21 xAOD tests that use docker to do the C++ compile and short runs
   atlas_r22_xaod_runner: Run ATLAS R22 xAOD tests that use docker to do the C++ compile and short runs

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -189,6 +189,7 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
+    os.system("ls -l /tmp")
     docker_cmd = f'docker run --rm -v {code_dir.absolute()}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;/scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -189,8 +189,7 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
-    os.chmod(os.path.join(code_dir, info.main_script), 0o755)
-    docker_cmd = f'docker run --rm -v {code_dir}:/scripts {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "chmod a+x /scripts/{info.main_script}; /scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "chmod a+x /scripts/{info.main_script}; /scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -121,7 +121,12 @@ class docker_running_container:
         "Get the docker command up and running"
         data_dir = self._files[0].parent
         self._results_dir = tempfile.TemporaryDirectory()
-        docker_cmd = f'docker run --name test_func_xAOD --rm -d -v {self._code_dir}:/scripts:ro -v {str(self._results_dir.name)}:/results -v {data_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /bin/bash -c "while [ 1 ] ; do sleep 1; echo hi ; done"'
+        code_dir = Path(self._code_dir)
+        code_dir.chmod(code_dir.stat().st_mode | 0o555)
+        results_dir = Path(self._results_dir.name)
+        results_dir.chmod(0x777)
+        data_dir.chmod(data_dir.stat().st_mode | 0o555)
+        docker_cmd = f'docker run --name test_func_xAOD --rm -d -v {code_dir}:/scripts:ro -v {str(results_dir)}:/results -v {data_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /bin/bash -c "while [ 1 ] ; do sleep 1; echo hi ; done"'
         r = os.system(docker_cmd)
         if r != 0:
             raise Exception(f"Unable to start docker deamon: {r}")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -77,7 +77,7 @@ class docker_runner:
         "Run the script as a compile"
 
         results_dir = tempfile.TemporaryDirectory()
-        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; source /scripts/{info.main_script} -c"'
+        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; chmod +x /scripts/{info.main_script}; -c"'
         result = os.system(docker_cmd)
         if result != 0:
             raise docker_run_error(f"nope, that didn't work {result}!")
@@ -99,7 +99,7 @@ class docker_runner:
 
         # Docker command
         results_dir = tempfile.TemporaryDirectory()
-        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; source /scripts/{info.main_script} {cmd_options}"'
+        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; chmod +x /scripts/{info.main_script}; /scripts/{info.main_script} {cmd_options}"'
         result = os.system(docker_cmd)
         if result != 0:
             raise docker_run_error(f"nope, that didn't work {result}!")
@@ -189,7 +189,7 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
-    docker_cmd = f"docker run --rm -v {code_dir}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 source /scripts/{info.main_script} {initial_args} {cmd_options}"
+    docker_cmd = f"docker run --rm -v {code_dir}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /scripts/{info.main_script} {initial_args} {cmd_options}"
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -189,7 +189,7 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
-    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l; ls -l /scripts; chmod a+x /scripts/{info.main_script}; /scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l; ls -l /scripts; source /scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -126,7 +126,7 @@ class docker_running_container:
         code_dir.chmod(code_dir.stat().st_mode | 0o555)
         data_dir = self._files[0].parent
         data_dir.chmod(data_dir.stat().st_mode | 0o555)
-        docker_cmd = f'docker run --name test_func_xAOD --rm -d -v {code_dir}:/scripts:ro -v {str(results_dir)}:/results -v {data_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /bin/bash -c "chmod a+rx /scripts; while [ 1 ] ; do sleep 1; echo hi ; done"'
+        docker_cmd = f'docker run --name test_func_xAOD --rm -d -v {code_dir}:/scripts:ro -v {str(results_dir)}:/results -v {data_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /bin/bash -c "while [ 1 ] ; do sleep 1; echo hi ; done"'
         r = os.system(docker_cmd)
         if r != 0:
             raise Exception(f"Unable to start docker deamon: {r} - {docker_cmd}")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -190,7 +190,7 @@ def run_docker(
 
     # Docker command
     os.chmod(os.path.join(code_dir, info.main_script), 0o755)
-    docker_cmd = f"docker run --rm -v {code_dir}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /scripts/{info.main_script} {initial_args} {cmd_options}"
+    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "chmod a+x /scripts/{info.main_script}; /scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -190,7 +190,7 @@ def run_docker(
 
     # Docker command
     os.system("ls -l /tmp")
-    docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/scripts:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;/scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/data1:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;/scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result} - {docker_cmd}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -99,7 +99,7 @@ class docker_runner:
 
         # Docker command
         results_dir = tempfile.TemporaryDirectory()
-        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; chmod +x /scripts/{info.main_script}; /scripts/{info.main_script} {cmd_options}"'
+        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; /scripts/{info.main_script} {cmd_options}"'
         result = os.system(docker_cmd)
         if result != 0:
             raise docker_run_error(f"nope, that didn't work {result}!")
@@ -126,7 +126,7 @@ class docker_running_container:
         code_dir.chmod(code_dir.stat().st_mode | 0o555)
         data_dir = self._files[0].parent
         data_dir.chmod(data_dir.stat().st_mode | 0o555)
-        docker_cmd = f'docker run --name test_func_xAOD --rm -d -v {code_dir}:/scripts:ro -v {str(results_dir)}:/results -v {data_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /bin/bash -c "while [ 1 ] ; do sleep 1; echo hi ; done"'
+        docker_cmd = f'docker run --name test_func_xAOD --rm -d -v {code_dir}:/scripts:ro -v {str(results_dir)}:/results -v {data_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /bin/bash -c "chmod a+rx /scripts; while [ 1 ] ; do sleep 1; echo hi ; done"'
         r = os.system(docker_cmd)
         if r != 0:
             raise Exception(f"Unable to start docker deamon: {r} - {docker_cmd}")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -190,7 +190,12 @@ def run_docker(
 
     # Docker command
     assert Path(code_dir).exists()
-    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw,z {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "chmod -R a+rw /scripts; ls -l /; ls -l /scripts; source /scripts/{info.main_script} {initial_args} {cmd_options}"'
+    for root, dirs, files in os.walk(code_dir):
+        for dir_name in dirs:
+            os.chmod(os.path.join(root, dir_name), 0o755)
+        for file_name in files:
+            os.chmod(os.path.join(root, file_name), 0o755)
+    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /; ls -l /scripts; source /scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -189,6 +189,7 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
+    os.chmod(os.path.join(code_dir, info.main_script), 0o755)
     docker_cmd = f"docker run --rm -v {code_dir}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /scripts/{info.main_script} {initial_args} {cmd_options}"
     result = os.system(docker_cmd)
     if result != 0:

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -14,7 +14,7 @@ from func_adl_xAOD.atlas.xaod.executor import atlas_xaod_executor
 
 from .config import local_path, run_long_running_tests
 
-pytestmark = run_long_running_tests
+# pytestmark = run_long_running_tests
 
 ExecutorInfo = namedtuple("ExecutorInfo", "main_script output_filename")
 
@@ -121,7 +121,7 @@ class docker_running_container:
         "Get the docker command up and running"
         data_dir = self._files[0].parent
         self._results_dir = tempfile.TemporaryDirectory()
-        docker_cmd = f'docker run --name test_func_xAOD --rm -d -v {self._code_dir}:/scripts:ro -v {str(self._results_dir.name)}:/results -v {data_dir.absolute()}:/data:ro atlas/analysisbase:21.2.234 /bin/bash -c "while [ 1 ] ; do sleep 1; echo hi ; done"'
+        docker_cmd = f'docker run --name test_func_xAOD --rm -d -v {self._code_dir}:/scripts:ro -v {str(self._results_dir.name)}:/results -v {data_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /bin/bash -c "while [ 1 ] ; do sleep 1; echo hi ; done"'
         r = os.system(docker_cmd)
         if r != 0:
             raise Exception(f"Unable to start docker deamon: {r}")
@@ -189,7 +189,7 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
-    docker_cmd = f"docker run --rm -v {code_dir}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro atlas/analysisbase:21.2.234 /scripts/{info.main_script} {initial_args} {cmd_options}"
+    docker_cmd = f"docker run --rm -v {code_dir}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /scripts/{info.main_script} {initial_args} {cmd_options}"
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -300,10 +300,12 @@ def test_good_cpp_compile_and_run_2_files(cache_directory):
     with docker_running_container(info, cache_directory, [Path(local_path)]) as runner:
         runner.compile(info)
         runner.run(info, [Path(local_path)])
-        out_file = os.path.join(runner.results_dir, info.output_filename)
-        os.unlink(out_file)
+        out_file = Path(runner.results_dir) / info.output_filename
+        assert out_file.exists()
+        out_file.chmod(0o777)
+        out_file.unlink()
         runner.run(info, [Path(local_path)])
-        assert os.path.exists(out_file)
+        assert out_file.exists()
 
 
 def test_run_with_bad_position_arg(cache_directory):

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -195,7 +195,7 @@ def run_docker(
             os.chmod(os.path.join(root, dir_name), 0o755)
         for file_name in files:
             os.chmod(os.path.join(root, file_name), 0o755)
-    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /; ls -l /scripts; source /scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "sudo \\"chmod a+rx /scripts\\"; ls -l /; ls -l /scripts; source /scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -190,8 +190,8 @@ def run_docker(
 
     # Docker command
     os.system("ls -l /tmp")
-    os.system("chmod a+rx {code_dir.absolute()}")
-    os.system("chmod a+rx {base_dir.absolute()}")
+    os.system(f"chmod a+rx {code_dir.absolute()}")
+    os.system(f"chmod a+rx {base_dir.absolute()}")
     os.system("echo after chmod")
     os.system("ls -l /tmp")
     docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/scripts:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;ls -l /home/atlas;/scripts/{info.main_script} {initial_args} {cmd_options}"'

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -309,8 +309,6 @@ def test_good_cpp_compile_and_run_2_files(cache_directory):
         runner.exec("chmod a+rw /results/ANALYSIS.root")
         out_file = Path(runner.results_dir) / info.output_filename
         assert out_file.exists()
-        os.system(f"ls {out_file.parent}")
-        # out_file.chmod(0o777)
         out_file.unlink()
         runner.run(info, [Path(local_path)])
         assert out_file.exists()

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -99,7 +99,7 @@ class docker_runner:
 
         # Docker command
         results_dir = tempfile.TemporaryDirectory()
-        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; /scripts/{info.main_script} {cmd_options}"'
+        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; source /scripts/{info.main_script} {cmd_options}"'
         result = os.system(docker_cmd)
         if result != 0:
             raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -185,7 +185,7 @@ def run_docker(
         mount_output_options = (
             f"-v {str(results_path)}:{output_dir}" if mount_output else ""
         )
-        results_path.chmod(Path(results_path).stat().st_mode | 0o500)
+        results_path.chmod(Path(results_path).stat().st_mode | 0o555)
 
     # Add an argument at the start?
     initial_args = ""
@@ -194,7 +194,7 @@ def run_docker(
 
     # Docker command
     os.system("ls -l /tmp")
-    code_dir.chmod(code_dir.stat().st_mode | 0o500)
+    code_dir.chmod(code_dir.stat().st_mode | 0o555)
     os.system("echo after chmod")
     os.system("ls -l /tmp")
     docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/scripts:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;ls -l /home/atlas;/scripts/{info.main_script} {initial_args} {cmd_options}"'

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -309,7 +309,8 @@ def test_good_cpp_compile_and_run_2_files(cache_directory):
         runner.exec("chmod a+rw /results/ANALYSIS.root")
         out_file = Path(runner.results_dir) / info.output_filename
         assert out_file.exists()
-        out_file.chmod(0o777)
+        os.system(f"ls {out_file.parent}")
+        # out_file.chmod(0o777)
         out_file.unlink()
         runner.run(info, [Path(local_path)])
         assert out_file.exists()

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -185,6 +185,7 @@ def run_docker(
         mount_output_options = (
             f"-v {str(results_path)}:{output_dir}" if mount_output else ""
         )
+        # Make sure we can write to this directory!
         results_path.chmod(Path(results_path).stat().st_mode | 0o777)
 
     # Add an argument at the start?
@@ -193,11 +194,8 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
-    os.system("ls -l /tmp")
     code_dir.chmod(code_dir.stat().st_mode | 0o555)
-    os.system("echo after chmod")
-    os.system("ls -l /tmp")
-    docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/scripts:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;ls -l /home/atlas;/scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f"docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/scripts:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /scripts/{info.main_script} {initial_args} {cmd_options}"
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result} - {docker_cmd}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -190,7 +190,7 @@ def run_docker(
 
     # Docker command
     os.chmod(os.path.join(code_dir, info.main_script), 0o755)
-    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "chmod a+x /scripts/{info.main_script}; /scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f'docker run --rm -v {code_dir}:/scripts {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "chmod a+x /scripts/{info.main_script}; /scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -190,7 +190,7 @@ def run_docker(
 
     # Docker command
     assert Path(code_dir).exists()
-    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /; ls -l /scripts; source /scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw,z {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "chmod -R a+rw /scripts; ls -l /; ls -l /scripts; source /scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -119,17 +119,17 @@ class docker_running_container:
 
     def __enter__(self):
         "Get the docker command up and running"
-        data_dir = self._files[0].parent
         self._results_dir = tempfile.TemporaryDirectory()
-        code_dir = Path(self._code_dir)
-        code_dir.chmod(code_dir.stat().st_mode | 0o555)
         results_dir = Path(self._results_dir.name)
         results_dir.chmod(0x777)
+        code_dir = Path(self._code_dir)
+        code_dir.chmod(code_dir.stat().st_mode | 0o555)
+        data_dir = self._files[0].parent
         data_dir.chmod(data_dir.stat().st_mode | 0o555)
         docker_cmd = f'docker run --name test_func_xAOD --rm -d -v {code_dir}:/scripts:ro -v {str(results_dir)}:/results -v {data_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /bin/bash -c "while [ 1 ] ; do sleep 1; echo hi ; done"'
         r = os.system(docker_cmd)
         if r != 0:
-            raise Exception(f"Unable to start docker deamon: {r}")
+            raise Exception(f"Unable to start docker deamon: {r} - {docker_cmd}")
         return docker_runner("test_func_xAOD", self._results_dir.name)
 
     def __exit__(self, type, value, traceback):

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -189,7 +189,7 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
-    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "chmod a+x /scripts/{info.main_script}; /scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l; ls -l /scripts; chmod a+x /scripts/{info.main_script}; /scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -190,7 +190,11 @@ def run_docker(
 
     # Docker command
     os.system("ls -l /tmp")
-    docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/data1:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;ls -l /home/atlas;/scripts/{info.main_script} {initial_args} {cmd_options}"'
+    os.system("chmod a+rx {code_dir.absolute()}")
+    os.system("chmod a+rx {base_dir.absolute()}")
+    os.system("echo after chmod")
+    os.system("ls -l /tmp")
+    docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/scripts:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;ls -l /home/atlas;/scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result} - {docker_cmd}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -185,7 +185,7 @@ def run_docker(
         mount_output_options = (
             f"-v {str(results_path)}:{output_dir}" if mount_output else ""
         )
-        results_path.chmod(Path(results_path).stat().st_mode | 0o555)
+        results_path.chmod(Path(results_path).stat().st_mode | 0o777)
 
     # Add an argument at the start?
     initial_args = ""

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -302,6 +302,8 @@ def test_good_cpp_compile_and_run_2_files(cache_directory):
         runner.run(info, [Path(local_path)])
         out_file = Path(runner.results_dir) / info.output_filename
         assert out_file.exists()
+        os.system(f"ls -l {out_file.parent}")
+        os.system(f"ls -l {out_file.parent.parent}")
         out_file.chmod(0o777)
         out_file.unlink()
         runner.run(info, [Path(local_path)])

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -14,7 +14,7 @@ from func_adl_xAOD.atlas.xaod.executor import atlas_xaod_executor
 
 from .config import local_path, run_long_running_tests
 
-# pytestmark = run_long_running_tests
+pytestmark = run_long_running_tests
 
 ExecutorInfo = namedtuple("ExecutorInfo", "main_script output_filename")
 

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -77,7 +77,7 @@ class docker_runner:
         "Run the script as a compile"
 
         results_dir = tempfile.TemporaryDirectory()
-        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; /scripts/{info.main_script} -c"'
+        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; source /scripts/{info.main_script} -c"'
         result = os.system(docker_cmd)
         if result != 0:
             raise docker_run_error(f"nope, that didn't work {result}!")
@@ -189,7 +189,7 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
-    docker_cmd = f"docker run --rm -v {code_dir}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 /scripts/{info.main_script} {initial_args} {cmd_options}"
+    docker_cmd = f"docker run --rm -v {code_dir}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 source /scripts/{info.main_script} {initial_args} {cmd_options}"
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -190,7 +190,7 @@ def run_docker(
 
     # Docker command
     os.system("ls -l /tmp")
-    docker_cmd = f'docker run --rm -v {code_dir.absolute()}:/scripts:ro {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;/scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/scripts:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;/scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result} - {docker_cmd}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -179,9 +179,13 @@ def run_docker(
         output_dir = "/results"
 
     results_dir = tempfile.TemporaryDirectory()
-    mount_output_options = (
-        f"-v {str(results_dir.name)}:{output_dir}" if mount_output else ""
-    )
+    mount_output_options = ""
+    if mount_output:
+        results_path = Path(results_dir.name)
+        mount_output_options = (
+            f"-v {str(results_path)}:{output_dir}" if mount_output else ""
+        )
+        results_path.chmod(Path(results_path).stat().st_mode | 0o500)
 
     # Add an argument at the start?
     initial_args = ""
@@ -190,8 +194,7 @@ def run_docker(
 
     # Docker command
     os.system("ls -l /tmp")
-    os.system(f"chmod a+rx {code_dir.absolute()}")
-    os.system(f"chmod a+rx {base_dir.absolute()}")
+    code_dir.chmod(code_dir.stat().st_mode | 0o500)
     os.system("echo after chmod")
     os.system("ls -l /tmp")
     docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/scripts:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;ls -l /home/atlas;/scripts/{info.main_script} {initial_args} {cmd_options}"'

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -77,10 +77,10 @@ class docker_runner:
         "Run the script as a compile"
 
         results_dir = tempfile.TemporaryDirectory()
-        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; chmod +x /scripts/{info.main_script}; -c"'
+        docker_cmd = f'docker exec {self._name} /bin/bash -c "cd /home/atlas; chmod +x /scripts/{info.main_script}; /scripts/{info.main_script} -c"'
         result = os.system(docker_cmd)
         if result != 0:
-            raise docker_run_error(f"nope, that didn't work {result}!")
+            raise docker_run_error(f"nope, that didn't work {result}! - {docker_cmd}")
         return results_dir
 
     def run(self, info: ExecutorInfo, files: List[Path]):

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -190,7 +190,7 @@ def run_docker(
 
     # Docker command
     os.system("ls -l /tmp")
-    docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/data1:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;/scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f'docker run --rm {mount_output_options} -v {base_dir.absolute()}:/data:ro -v {code_dir.absolute()}:/data1:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /;ls -l /home/atlas;/scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result} - {docker_cmd}!")

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -189,6 +189,7 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
+    assert Path(code_dir).exists()
     docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /; ls -l /scripts; source /scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:

--- a/tests/atlas/xaod/test_cpp_script_control.py
+++ b/tests/atlas/xaod/test_cpp_script_control.py
@@ -189,7 +189,7 @@ def run_docker(
         initial_args = f"{add_position_argument_at_start} "
 
     # Docker command
-    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l; ls -l /scripts; source /scripts/{info.main_script} {initial_args} {cmd_options}"'
+    docker_cmd = f'docker run --rm -v {code_dir}:/scripts:rw {mount_output_options} -v {base_dir.absolute()}:/data:ro gitlab-registry.cern.ch/atlas/athena/analysisbase:25.2.42 bash -c "ls -l /; ls -l /scripts; source /scripts/{info.main_script} {initial_args} {cmd_options}"'
     result = os.system(docker_cmd)
     if result != 0:
         raise docker_run_error(f"nope, that didn't work {result}!")


### PR DESCRIPTION
* Looked into enabling docker for the tests. But...
  * The windows docker now only seems to run windows images
  * MacOS doesn't have docker installed, and you have to install it - which has intermitent failures
  * The full test on Linux is now up to 43 minutes (!)
  * CMS image layers seem to be corrupt.

As a result, this PR is about cleaning things up a bit

* Make sure that linux permissions now work (this is a run-as-admin vs run-as-user issue)
* Run on push to a non-master branch associated with a pull request. Prevents the CI from running twice with each commit on a branch.
* Change defalt behavior of `pytest` so it won't run the docker items
* Turn off code coverage running by default.

Run tests correctly out of the box for development 
Fixes #258