### PR TITLE
Clean up test warnings & Start testing with 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.platform }}
     needs: flake8
 

--- a/func_adl_xAOD/common/ast_to_cpp_translator.py
+++ b/func_adl_xAOD/common/ast_to_cpp_translator.py
@@ -1046,23 +1046,6 @@ class query_ast_visitor(FuncADLNodeVisitor, ABC):
         else:
             raise ValueError(f"Unsupported constant type: {type(value)}")
 
-    def visit_NameConstant(self, node: ast.NameConstant):
-        value = node.value
-        if value is True:
-            crep.set_rep(
-                node,
-                crep.cpp_value("true", self._gc.current_scope(), ctyp.terminal("bool")),
-            )
-        elif value is False:
-            crep.set_rep(
-                node,
-                crep.cpp_value(
-                    "false", self._gc.current_scope(), ctyp.terminal("bool")
-                ),
-            )
-        else:
-            raise ValueError(f"Unsupported constant: {value}")
-
     def code_fill_ttree(
         self,
         e_rep: crep.cpp_rep_base,

--- a/func_adl_xAOD/common/event_collections.py
+++ b/func_adl_xAOD/common/event_collections.py
@@ -16,31 +16,36 @@ class event_collection_container(ctyp.terminal, ABC):
 
     @abstractmethod
     def __str__(self) -> str:
-        '''Return the string representation of this event collection.
+        """Return the string representation of this event collection.
         Helpful for identifying it in ast dumps
 
         Returns:
             str: Description
-        '''
+        """
 
 
 class event_collection_collection_container(ctyp.collection, ABC):
-    def __init__(self, type_name: Union[str, ctyp.CPPParsedTypeInfo],
-                 element_name: Union[str, ctyp.CPPParsedTypeInfo],
-                 p_depth_type: int, p_depth_element: int):
+    def __init__(
+        self,
+        type_name: Union[str, ctyp.CPPParsedTypeInfo],
+        element_name: Union[str, ctyp.CPPParsedTypeInfo],
+        p_depth_type: int,
+        p_depth_element: int,
+    ):
         super().__init__(
             ctyp.terminal(element_name, p_depth=p_depth_element),
-            array_type=type_name, p_depth=p_depth_type
+            array_type=type_name,
+            p_depth=p_depth_type,
         )
 
     @abstractmethod
     def __str__(self) -> str:
-        '''Return the string representation of this event collection.
+        """Return the string representation of this event collection.
         Helpful for identifying it in ast dumps
 
         Returns:
             str: Description
-        '''
+        """
 
 
 @dataclass
@@ -52,57 +57,75 @@ class EventCollectionSpecification:
     include_files: List[str]
 
     # The container information
-    container_type: Union[event_collection_container, event_collection_collection_container]
+    container_type: Union[
+        event_collection_container, event_collection_collection_container
+    ]
 
     # List of libraries (e.g. ['xAODJet'])
     libraries: List[str]
 
 
 class event_collection_coder(ABC):
-    '''Contains code to generate collections accessing code in the backend
-    '''
+    """Contains code to generate collections accessing code in the backend"""
+
     def get_collection(self, md: EventCollectionSpecification, call_node: ast.Call):
-        r'''
+        r"""
         Return a cpp ast for accessing the jet collection with the given arguments.
-        '''
+        """
         # Get the name jet collection to look at.
         if len(call_node.args) != 1:
             raise ValueError(f"Calling {md.name} - only one argument is allowed")
-        if not isinstance(call_node.args[0], ast.Str):
-            raise ValueError(f"Calling {md.name} - only acceptable argument is a string")
+        if not (
+            isinstance(call_node.args[0], ast.Constant)
+            and isinstance(call_node.args[0].value, str)
+        ):
+            raise ValueError(
+                f"Calling {md.name} - only acceptable argument is a string"
+            )
 
         # Fill in the CPP block next.
         r = cpp_ast.CPPCodeValue()
-        r.args = ['collection_name', ]
+        r.args = [
+            "collection_name",
+        ]
         r.include_files += md.include_files
         r.link_libraries += md.libraries
 
         self.get_running_code_CPPCodeValue(r, md)
-        r.result = 'result'
+        r.result = "result"
 
         if issubclass(type(md.container_type), event_collection_collection_container):
             r.result_rep = lambda scope: crep.cpp_collection(unique_name(md.name.lower()), scope=scope, collection_type=md.container_type)  # type: ignore
         else:
-            r.result_rep = lambda scope: crep.cpp_variable(unique_name(md.name.lower()), scope=scope, cpp_type=md.container_type)
+            r.result_rep = lambda scope: crep.cpp_variable(
+                unique_name(md.name.lower()), scope=scope, cpp_type=md.container_type
+            )
 
         # Replace it as a function that is going to get called.
         call_node.func = r  # type: ignore
         return call_node
 
-    def get_running_code_CPPCodeValue(self, cpv: cpp_ast.CPPCodeValue, md: EventCollectionSpecification):
-        r'''
+    def get_running_code_CPPCodeValue(
+        self, cpv: cpp_ast.CPPCodeValue, md: EventCollectionSpecification
+    ):
+        r"""
         Put the running code information stored in EventCollectionSpecification into CPPCodeValue. Can be
         overridden to store extra information(such as variable declarations).
-        '''
+        """
         cpv.running_code = self.get_running_code(md.container_type)
 
     @abstractmethod
-    def get_running_code(self, container_type: Union[event_collection_container, event_collection_collection_container]) -> List[str]:
-        '''Return the code that will extract the collection from the event object
+    def get_running_code(
+        self,
+        container_type: Union[
+            event_collection_container, event_collection_collection_container
+        ],
+    ) -> List[str]:
+        """Return the code that will extract the collection from the event object
 
         Args:
             container_type (event_collection_container): The container to extract.
 
         Returns:
             List[str]: Lines of C++ code to execute to get this out.
-        '''
+        """

--- a/func_adl_xAOD/common/local_dataset.py
+++ b/func_adl_xAOD/common/local_dataset.py
@@ -27,6 +27,7 @@ class docker_volume_info:
 @dataclass
 class DockerImageSpecification:
     "The image to run for docker"
+
     image: str
 
 
@@ -90,8 +91,8 @@ class LocalDataset(EventDataset, ABC):
 
         # Put everything into the ast so that we can safely be carried over qastle and used in
         # determining a hash key to see when things change.
-        self.query_ast.args.append(ast.Str(s=f"{self._docker_image}"))  # type: ignore
-        self.query_ast.args.append(ast.List(elts=[ast.Str(s=str(f)) for f in self.files]))  # type: ignore
+        self.query_ast.args.append(ast.Constant(value=f"{self._docker_image}"))  # type: ignore
+        self.query_ast.args.append(ast.List(elts=[ast.Constant(value=str(f)) for f in self.files]))  # type: ignore
 
     @abstractmethod
     def get_executor_obj(self) -> executor:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+import asyncio
+
 import pytest
+
 import func_adl_xAOD.common.cpp_types as ctyp
 
 
@@ -10,3 +13,12 @@ def clear_method_type_info():
     yield
     ctyp.g_method_type_dict = {}
     ctyp.g_toplevel_ns = {}
+
+
+@pytest.fixture(autouse=True)
+def get_loop():
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:  # No running loop
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)


### PR DESCRIPTION
* Removed use of `ast.NameConstant`
* Remove `ast.Str`
* Make sure thre is an async io event loop in all tests.
* Added 3.13 to the text matrix

Fixes #236