### PR TITLE
Fix: push_back in nested loop placed in wrong context

### DIFF
--- a/func_adl_xAOD/common/cpp_representation.py
+++ b/func_adl_xAOD/common/cpp_representation.py
@@ -307,6 +307,7 @@ class cpp_sequence(cpp_rep_base):
         sequence_value: Union[cpp_value, cpp_sequence],
         iterator_value: cpp_value,
         scope: Union[gc_scope_top_level, gc_scope],
+        node: ast.expr,
     ):
         """
         Create a sequence
@@ -320,12 +321,14 @@ class cpp_sequence(cpp_rep_base):
                                 inside the if statement of the Where, while the iterator will be at the scope of
                                 the original declaration. If the `sequence_value` is an actual value, it will have
                                 the same scope.
+        node:                   The AST node associated with this sequence.
         """
         cpp_rep_base.__init__(self)
         self._sequence = sequence_value
         self._iterator = iterator_value
         self._type: Optional[ctyp.collection] = None
         self._scope = scope
+        self._node = node
 
     def sequence_value(self):
         return self._sequence
@@ -344,6 +347,10 @@ class cpp_sequence(cpp_rep_base):
     def scope(self) -> Union[gc_scope, gc_scope_top_level]:
         "Return scope where this sequence was created/valid"
         return self._scope
+
+    def node(self) -> ast.expr:
+        "Node in ast tree where this sequence is defined."
+        return self._node
 
 
 def set_rep(node: ast.AST, value: cpp_rep_base, scope: Optional[Any] = None):

--- a/func_adl_xAOD/common/executor.py
+++ b/func_adl_xAOD/common/executor.py
@@ -272,7 +272,9 @@ class executor(ABC):
         iterator = crep.cpp_variable(
             "bogus-do-not-use", top_level_scope(), cpp_type=None
         )
-        crep.set_rep(file, crep.cpp_sequence(iterator, iterator, top_level_scope()))
+        crep.set_rep(
+            file, crep.cpp_sequence(iterator, iterator, top_level_scope(), file)
+        )
 
         # Visit the AST to generate the code structure and find out what the
         # result is going to be.

--- a/tests/atlas/r22_xaod/utils.py
+++ b/tests/atlas/r22_xaod/utils.py
@@ -62,7 +62,7 @@ async def exe_from_qastle(q: str):
 
     file = find_EventDataset(a)
     iterator = cpp_variable("bogus-do-not-use", top_level_scope(), cpp_type=None)
-    set_rep(file, cpp_sequence(iterator, iterator, top_level_scope()))
+    set_rep(file, cpp_sequence(iterator, iterator, top_level_scope(), file))
 
     # Use the dummy executor to process this, and return it.
     exe = atlas_xaodr22_dummy_executor()
@@ -83,7 +83,7 @@ def load_root_as_pandas(file: Path) -> pd.DataFrame:
     assert isinstance(file, Path)
     assert file.exists()
 
-    with uproot.open(file) as input:
+    with uproot.open(file) as input:  # type: ignore
         return input["atlas_xaod_tree"].arrays(library="pd")  # type: ignore
 
 
@@ -100,7 +100,7 @@ def load_root_as_awkward(file: Path) -> ak.Array:
     assert isinstance(file, Path)
     assert file.exists()
 
-    with uproot.open(file) as input:
+    with uproot.open(file) as input:  # type: ignore
         return input["atlas_xaod_tree"].arrays()  # type: ignore
 
 

--- a/tests/atlas/xaod/test_first_last.py
+++ b/tests/atlas/xaod/test_first_last.py
@@ -1,6 +1,6 @@
 # Code to do the testing starts here.
 import func_adl_xAOD.common.cpp_types as ctyp
-from tests.utils.locators import find_line_numbers_with, find_line_with, find_next_closing_bracket, find_open_blocks  # type: ignore
+from tests.utils.locators import find_line_numbers_with, find_line_with, find_next_closing_bracket  # type: ignore
 from tests.utils.general import get_lines_of_code, print_lines  # type: ignore
 from tests.atlas.xaod.utils import atlas_xaod_dataset  # type: ignore
 import re
@@ -90,7 +90,9 @@ def test_First_Of_Select_is_not_array():
     l_first_test = l_first_tests[1]
 
     # Ensure the indent columns in lines[l_fill] and lines[l_first_test] are the same
-    assert lines[l_fill].startswith(" " * (len(lines[l_first_test]) - len(lines[l_first_test].lstrip())))
+    assert lines[l_fill].startswith(
+        " " * (len(lines[l_first_test]) - len(lines[l_first_test].lstrip()))
+    )
 
 
 def test_First_Of_Select_After_Where_is_in_right_place():

--- a/tests/atlas/xaod/test_query_ast_visitor.py
+++ b/tests/atlas/xaod/test_query_ast_visitor.py
@@ -166,6 +166,7 @@ def test_as_root_as_dict():
         dict_obj,  # type: ignore
         crep.cpp_value("i", gc_scope_top_level(), ctyp.terminal("int")),
         gc_scope_top_level(),
+        node,
     )
     node.rep = sequence  # type: ignore
     as_root = q.get_as_ROOT(node)
@@ -181,6 +182,7 @@ def test_as_root_as_single_column():
         value_obj,
         crep.cpp_value("i", gc_scope_top_level(), ctyp.terminal("int")),
         gc_scope_top_level(),
+        node,
     )
     node.rep = sequence  # type: ignore
     as_root = q.get_as_ROOT(node)
@@ -200,6 +202,7 @@ def test_as_root_as_tuple():
         value_obj,  # type: ignore
         crep.cpp_value("i", gc_scope_top_level(), ctyp.terminal("int")),
         gc_scope_top_level(),
+        node,
     )
     node.rep = sequence  # type: ignore
     as_root = q.get_as_ROOT(node)

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -286,7 +286,6 @@ def test_where_at_top_level_First_and_count():
     print_lines(lines)
 
     # Make sure we are grabbing the jet container and the fill at the same indent level.
-    i_pt_test = find_line_with(">1001.0", lines)
     i_fill = find_line_with("->Fill()", lines)
     assert 4 == len(lines[i_fill]) - len(lines[i_fill].lstrip())
 
@@ -439,7 +438,7 @@ def test_per_jet_item_with_where():
 
 
 def test_where_in_sub_select():
-    "We have an if statement buried in a loop - make sure pushback is done right"
+    "We have an if statement buried in a loop - make sure push_back is done right"
     r = (
         atlas_xaod_dataset()
         .Select(

--- a/tests/atlas/xaod/test_xaod_executor.py
+++ b/tests/atlas/xaod/test_xaod_executor.py
@@ -438,6 +438,29 @@ def test_per_jet_item_with_where():
     assert "Fill()" in lines[l_jet_pt + 1]
 
 
+def test_where_in_sub_select():
+    "We have an if statement buried in a loop - make sure pushback is done right"
+    r = (
+        atlas_xaod_dataset()
+        .Select(
+            lambda e: [
+                [t.pt for t in e.Tracks("hi")] for j in e.Jets("hi") if j.pt() > 10
+            ]
+        )
+        .value()
+    )
+
+    lines = get_lines_of_code(r)
+    print_lines(lines)
+
+    # Make sure we are grabbing the jet container and the fill at the same indent level.
+    i_if = find_line_with("pt()>10", lines)
+    i_if_indent = len(lines[i_if]) - len(lines[i_if].lstrip())
+    i_fill = find_line_with(".push_back(ntuple", lines)
+    i_fill_indent = len(lines[i_fill]) - len(lines[i_fill].lstrip())
+    assert i_if_indent < i_fill_indent
+
+
 def test_and_clause_in_where():
     # The following statement should be a straight sequence, not an array.
     r = (

--- a/tests/atlas/xaod/utils.py
+++ b/tests/atlas/xaod/utils.py
@@ -60,7 +60,7 @@ async def exe_from_qastle(q: str):
 
     file = find_EventDataset(a)
     iterator = cpp_variable("bogus-do-not-use", top_level_scope(), cpp_type=None)
-    set_rep(file, cpp_sequence(iterator, iterator, top_level_scope()))
+    set_rep(file, cpp_sequence(iterator, iterator, top_level_scope(), file))
 
     # Use the dummy executor to process this, and return it.
     exe = atlas_xaod_dummy_executor()

--- a/tests/cms/aod/utils.py
+++ b/tests/cms/aod/utils.py
@@ -49,16 +49,18 @@ class CMSAODLocalFile(LocalFile):
 
 
 async def exe_from_qastle(q: str):
-    'Dummy executor that will return the ast properly rendered. If qastle_roundtrip is true, then we will round trip the ast via qastle first.'
+    "Dummy executor that will return the ast properly rendered. If qastle_roundtrip is true, then we will round trip the ast via qastle first."
     # Round trip qastle if requested.
     import qastle
+
     a = qastle.text_ast_to_python_ast(q).body[0].value
 
     # Setup the rep for this filter
     from func_adl import find_EventDataset
+
     file = find_EventDataset(a)
     iterator = cpp_variable("bogus-do-not-use", top_level_scope(), cpp_type=None)
-    set_rep(file, cpp_sequence(iterator, iterator, top_level_scope()))
+    set_rep(file, cpp_sequence(iterator, iterator, top_level_scope(), file))
 
     # Use the dummy executor to process this, and return it.
     exe = dummy_executor()  # type: ignore
@@ -67,7 +69,7 @@ async def exe_from_qastle(q: str):
 
 
 def load_root_as_pandas(file: Path) -> pd.DataFrame:
-    '''Given the result from a query as a ROOT file path, return
+    """Given the result from a query as a ROOT file path, return
     the contents as a pandas dataframe.
 
     Args:
@@ -75,16 +77,16 @@ def load_root_as_pandas(file: Path) -> pd.DataFrame:
 
     Returns:
         pandas.DataFrame: [description]
-    '''
+    """
     assert isinstance(file, Path)
     assert file.exists()
 
     with uproot.open(file) as input:
-        return input['cms_aod_tree'].arrays(library='pd')  # type: ignore
+        return input["cms_aod_tree"].arrays(library="pd")  # type: ignore
 
 
 def load_root_as_awkward(file: Path) -> ak.Array:
-    '''Given the result from a query as a ROOT file path, return
+    """Given the result from a query as a ROOT file path, return
     the contents as a pandas dataframe.
 
     Args:
@@ -92,52 +94,54 @@ def load_root_as_awkward(file: Path) -> ak.Array:
 
     Returns:
         pandas.DataFrame: [description]
-    '''
+    """
     assert isinstance(file, Path)
     assert file.exists()
 
     with uproot.open(file) as input:
-        return input['demo/cms_aod_tree'].arrays()  # type: ignore
+        return input["demo/cms_aod_tree"].arrays()  # type: ignore
 
 
 def as_pandas(o: ObjectStream) -> pd.DataFrame:
-    '''Return a query as a pandas dataframe.
+    """Return a query as a pandas dataframe.
 
     Args:
         o (ObjectStream): The query
 
     Returns:
         pd.DataFrame: The result
-    '''
+    """
     return load_root_as_pandas(o.value())
 
 
 def as_awkward(o: ObjectStream) -> ak.Array:
-    '''Return a query as a pandas dataframe.
+    """Return a query as a pandas dataframe.
 
     Args:
         o (ObjectStream): The query
 
     Returns:
         pd.DataFrame: The result
-    '''
+    """
     return load_root_as_awkward(o.value())
 
 
 async def as_pandas_async(o: ObjectStream) -> pd.DataFrame:
-    '''Return a query as a pandas dataframe.
+    """Return a query as a pandas dataframe.
 
     Args:
         o (ObjectStream): The query
 
     Returns:
         pd.DataFrame: The result
-    '''
+    """
     return load_root_as_pandas(await o.value_async())
 
 
-def ast_parse_with_replacement(ast_string: str, replacements: Dict[str, ast.AST]) -> ast.AST:
-    '''Returns an ast, where any ast.Name elements are replaced by the ast that is in
+def ast_parse_with_replacement(
+    ast_string: str, replacements: Dict[str, ast.AST]
+) -> ast.AST:
+    """Returns an ast, where any ast.Name elements are replaced by the ast that is in
     the dict.
 
     Args:
@@ -146,7 +150,7 @@ def ast_parse_with_replacement(ast_string: str, replacements: Dict[str, ast.AST]
 
     Returns:
         (ast.AST): Ast from the parse, with the names replaced.
-    '''
+    """
     a = ast.parse(ast_string)
 
     class replacer(ast.NodeTransformer):

--- a/tests/cms/miniaod/utils.py
+++ b/tests/cms/miniaod/utils.py
@@ -39,7 +39,9 @@ class CMSminiAODDockerException(Exception):
 
 class CMSminiAODLocalFile(LocalFile):
     def __init__(self, local_files: Union[Path, List[Path]]):
-        super().__init__("cmsopendata/cmssw_7_6_7-slc6_amd64_gcc493", "Analyzer.cc", local_files)
+        super().__init__(
+            "cmsopendata/cmssw_7_6_7-slc6_amd64_gcc493", "Analyzer.cc", local_files
+        )
 
     def raise_docker_exception(self, message: str):
         raise CMSminiAODDockerException(message)
@@ -49,16 +51,18 @@ class CMSminiAODLocalFile(LocalFile):
 
 
 async def exe_from_qastle(q: str):
-    'Dummy executor that will return the ast properly rendered. If qastle_roundtrip is true, then we will round trip the ast via qastle first.'
+    "Dummy executor that will return the ast properly rendered. If qastle_roundtrip is true, then we will round trip the ast via qastle first."
     # Round trip qastle if requested.
     import qastle
+
     a = qastle.text_ast_to_python_ast(q).body[0].value
 
     # Setup the rep for this filter
     from func_adl import find_EventDataset
+
     file = find_EventDataset(a)
     iterator = cpp_variable("bogus-do-not-use", top_level_scope(), cpp_type=None)
-    set_rep(file, cpp_sequence(iterator, iterator, top_level_scope()))
+    set_rep(file, cpp_sequence(iterator, iterator, top_level_scope(), file))
 
     # Use the dummy executor to process this, and return it.
     exe = dummy_executor()  # type: ignore
@@ -67,7 +71,7 @@ async def exe_from_qastle(q: str):
 
 
 def load_root_as_pandas(file: Path) -> pd.DataFrame:
-    '''Given the result from a query as a ROOT file path, return
+    """Given the result from a query as a ROOT file path, return
     the contents as a pandas dataframe.
 
     Args:
@@ -75,16 +79,16 @@ def load_root_as_pandas(file: Path) -> pd.DataFrame:
 
     Returns:
         pandas.DataFrame: [description]
-    '''
+    """
     assert isinstance(file, Path)
     assert file.exists()
 
     with uproot.open(file) as input:
-        return input['cms_miniaod_tree'].arrays(library='pd')  # type: ignore
+        return input["cms_miniaod_tree"].arrays(library="pd")  # type: ignore
 
 
 def load_root_as_awkward(file: Path) -> ak.Array:
-    '''Given the result from a query as a ROOT file path, return
+    """Given the result from a query as a ROOT file path, return
     the contents as a pandas dataframe.
 
     Args:
@@ -92,52 +96,54 @@ def load_root_as_awkward(file: Path) -> ak.Array:
 
     Returns:
         pandas.DataFrame: [description]
-    '''
+    """
     assert isinstance(file, Path)
     assert file.exists()
 
     with uproot.open(file) as input:
-        return input['demo/cms_miniaod_tree'].arrays()  # type: ignore
+        return input["demo/cms_miniaod_tree"].arrays()  # type: ignore
 
 
 def as_pandas(o: ObjectStream) -> pd.DataFrame:
-    '''Return a query as a pandas dataframe.
+    """Return a query as a pandas dataframe.
 
     Args:
         o (ObjectStream): The query
 
     Returns:
         pd.DataFrame: The result
-    '''
+    """
     return load_root_as_pandas(o.value())
 
 
 def as_awkward(o: ObjectStream) -> ak.Array:
-    '''Return a query as a pandas dataframe.
+    """Return a query as a pandas dataframe.
 
     Args:
         o (ObjectStream): The query
 
     Returns:
         pd.DataFrame: The result
-    '''
+    """
     return load_root_as_awkward(o.value())
 
 
 async def as_pandas_async(o: ObjectStream) -> pd.DataFrame:
-    '''Return a query as a pandas dataframe.
+    """Return a query as a pandas dataframe.
 
     Args:
         o (ObjectStream): The query
 
     Returns:
         pd.DataFrame: The result
-    '''
+    """
     return load_root_as_pandas(await o.value_async())
 
 
-def ast_parse_with_replacement(ast_string: str, replacements: Dict[str, ast.AST]) -> ast.AST:
-    '''Returns an ast, where any ast.Name elements are replaced by the ast that is in
+def ast_parse_with_replacement(
+    ast_string: str, replacements: Dict[str, ast.AST]
+) -> ast.AST:
+    """Returns an ast, where any ast.Name elements are replaced by the ast that is in
     the dict.
 
     Args:
@@ -146,7 +152,7 @@ def ast_parse_with_replacement(ast_string: str, replacements: Dict[str, ast.AST]
 
     Returns:
         (ast.AST): Ast from the parse, with the names replaced.
-    '''
+    """
     a = ast.parse(ast_string)
 
     class replacer(ast.NodeTransformer):

--- a/tests/common/test_ast_to_cpp_translator.py
+++ b/tests/common/test_ast_to_cpp_translator.py
@@ -2,7 +2,6 @@ import ast
 from typing import Callable
 
 from func_adl import ObjectStream
-from pandas.tests.api import test_types
 
 import func_adl_xAOD.common.cpp_representation as crep
 import func_adl_xAOD.common.cpp_types as ctyp

--- a/tests/common/test_ast_to_cpp_translator.py
+++ b/tests/common/test_ast_to_cpp_translator.py
@@ -55,7 +55,7 @@ def get_ast(r: ObjectStream, t="int", is_collection: bool = False) -> ast.AST:
         )
 
     file = find_EventDataset(r.query_ast)
-    crep.set_rep(file, crep.cpp_sequence(iterator, iterator, top_level_scope()))
+    crep.set_rep(file, crep.cpp_sequence(iterator, iterator, top_level_scope(), file))
 
     return my_executor([], "my_runner", "template_name", {}).apply_ast_transformations(
         r.query_ast

--- a/tests/common/test_cpp_representation.py
+++ b/tests/common/test_cpp_representation.py
@@ -1,3 +1,4 @@
+import ast
 import func_adl_xAOD.common.cpp_representation as crep
 import func_adl_xAOD.common.cpp_types as ctyp
 import pytest
@@ -72,7 +73,7 @@ def test_sequence_type():
     s_value = crep.cpp_value("0.0", tc, ctyp.terminal("int", False))
     i_value = crep.cpp_value("1.0", tc, ctyp.terminal("object", False))
 
-    seq = crep.cpp_sequence(s_value, i_value, tc)
+    seq = crep.cpp_sequence(s_value, i_value, tc, ast.Name("sequence_name"))
 
     assert seq.sequence_value().cpp_type().type == "int"
 
@@ -82,8 +83,8 @@ def test_sequence_type_2():
     s_value = crep.cpp_value("0.0", tc, ctyp.terminal("int", False))
     i_value = crep.cpp_value("1.0", tc, ctyp.terminal("object", False))
 
-    seq = crep.cpp_sequence(s_value, i_value, tc)
-    seq_array = crep.cpp_sequence(seq, i_value, tc)
+    seq = crep.cpp_sequence(s_value, i_value, tc, ast.Name("sequence_name"))
+    seq_array = crep.cpp_sequence(seq, i_value, tc, ast.Name("sequence_name"))
 
     assert seq_array.sequence_value().cpp_type().type == "std::vector<int>"
 

--- a/tests/utils/base.py
+++ b/tests/utils/base.py
@@ -208,7 +208,7 @@ class dataset(EventDataset, ABC):
 
         file = find_EventDataset(a)
         iterator = cpp_variable("bogus-do-not-use", top_level_scope(), cpp_type=None)
-        set_rep(file, cpp_sequence(iterator, iterator, top_level_scope()))
+        set_rep(file, cpp_sequence(iterator, iterator, top_level_scope(), file))
 
         # Use the dummy executor to process this, and return it.
         exe = self.get_dummy_executor_obj()


### PR DESCRIPTION
* Use the same scope determining logic as used for the outter loop in #255 for the inner loop
* Track the ast node that generates a sequence along with the sequence.

Fixes #267